### PR TITLE
Bugfix/warm start full model

### DIFF
--- a/rapidfireai/experiment.py
+++ b/rapidfireai/experiment.py
@@ -5,7 +5,8 @@ This module contains the Experiment class which manages the entire experiment li
 import multiprocessing as mp
 import os
 import traceback
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 import pandas as pd
 from torch.utils.data import Dataset
@@ -17,6 +18,7 @@ from rapidfireai.utils.exceptions import ExperimentException
 from rapidfireai.utils.experiment_utils import ExperimentUtils
 from rapidfireai.utils.logging import RFLogger
 from rapidfireai.utils.mlflow_manager import MLflowManager
+from rapidfireai.version import __version__
 
 
 class Experiment:
@@ -61,6 +63,8 @@ class Experiment:
             self.logger = RFLogger().create_logger("experiment")
             for msg in log_messages:
                 self.logger.info(msg)
+            # Log the version of rapidfireai that is running
+            self.logger.info(f"Running RapidFire AI version {__version__}")
         except Exception as e:
             raise ExperimentException(f"Error creating logger: {e}, traceback: {traceback.format_exc()}") from e
 

--- a/rapidfireai/utils/shm_manager.py
+++ b/rapidfireai/utils/shm_manager.py
@@ -460,7 +460,7 @@ class SharedMemoryManager:
                     dict(self._registry[warm_started_from])[SHMObjectType.CHECKPOINTS]
                 )
             self._registry[model_id] = model_entry
-            self.logger.debug(f"Copied warm start checkpoint from {warm_started_from} to {model_id}")
+            self.logger.debug(f"Copied warm start checkpoint from run {warm_started_from} to run {model_id}")
 
     def list_models(self):
         """Get list of all model IDs currently in shared memory."""

--- a/rapidfireai/utils/shm_manager.py
+++ b/rapidfireai/utils/shm_manager.py
@@ -286,7 +286,7 @@ class SharedMemoryManager:
             # create model entry in registry
             if model_id not in self._registry:
                 self._registry[model_id] = {SHMObjectType.CHECKPOINTS: {}}
-                
+
             model_entry = self._registry[model_id]
             if SHMObjectType.CHECKPOINTS not in model_entry:
                 model_entry[SHMObjectType.CHECKPOINTS] = {}
@@ -445,16 +445,20 @@ class SharedMemoryManager:
                     SHMObjectType.CHECKPOINTS: {},
                 }
 
+            # copy full_model, ref_state_dict, and checkpoints from warm_started_from to model_id
             model_entry = dict(self._registry[model_id])
-            model_entry[SHMObjectType.FULL_MODEL] = copy.deepcopy(
-                dict(self._registry[warm_started_from])[SHMObjectType.FULL_MODEL]
-            )
-            model_entry[SHMObjectType.REF_STATE_DICT] = copy.deepcopy(
-                dict(self._registry[warm_started_from])[SHMObjectType.REF_STATE_DICT]
-            )
-            model_entry[SHMObjectType.CHECKPOINTS] = copy.deepcopy(
-                dict(self._registry[warm_started_from])[SHMObjectType.CHECKPOINTS]
-            )
+            if SHMObjectType.FULL_MODEL in self._registry[warm_started_from]:
+                model_entry[SHMObjectType.FULL_MODEL] = copy.deepcopy(
+                    dict(self._registry[warm_started_from])[SHMObjectType.FULL_MODEL]
+                )
+            if SHMObjectType.REF_STATE_DICT in self._registry[warm_started_from]:
+                model_entry[SHMObjectType.REF_STATE_DICT] = copy.deepcopy(
+                    dict(self._registry[warm_started_from])[SHMObjectType.REF_STATE_DICT]
+                )
+            if SHMObjectType.CHECKPOINTS in self._registry[warm_started_from]:
+                model_entry[SHMObjectType.CHECKPOINTS] = copy.deepcopy(
+                    dict(self._registry[warm_started_from])[SHMObjectType.CHECKPOINTS]
+                )
             self._registry[model_id] = model_entry
             self.logger.debug(f"Copied warm start checkpoint from {warm_started_from} to {model_id}")
 


### PR DESCRIPTION
## Summary
This PR adds checks to the copying of shared-memory entries in the SHMManager class.
- We check if each key among `FULL_MODEL`, `REF_STATE_DICT` and `CHECKPOINTS` exist before attempting to copy these entries from the parent run to the cloned run.
Without these checks, we were running into KeyNotFound errors during clone-modify with warm start.
- Minor change - added RF version numbers to the log during experiment creation for better clarity during log inspections at a later date.

## Changes
- Added checks in `create_warm_start_checkpoint` method in `shm_manager.py`. This method is only triggered during clone-modify warm start operations.
- added logging of rf version number in Experiment class's init method.

## Testing
Tested E2E on sft-chatbot-lite notebook.

## Screenshots
- Error message showcasing KeyError due to lack of checks before copying FULL_MODEL entry from parent to clone:
<img width="1360" height="440" alt="Screenshot 2025-09-12 at 1 39 29 AM" src="https://github.com/user-attachments/assets/c43259e5-1516-4102-86c5-591747c0f562" />
- Logs from the fixed code that show successful copy of entries from parent to clone:
<img width="1494" height="933" alt="Screenshot 2025-09-12 at 1 41 50 AM" src="https://github.com/user-attachments/assets/eb2c5d43-8dd6-4da6-81a1-08806218916e" />
- Loss curves of Run 2(parent) and Run5(clone):
<img width="1575" height="815" alt="Screenshot 2025-09-12 at 1 42 38 AM" src="https://github.com/user-attachments/assets/69bec84e-7784-4b95-8ea9-71d0c3ee45fe" />

