### PR TITLE
Release/v0.9.11

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -13,12 +13,12 @@ rm -rf dist/ *.egg-info/ .eggs/ && python -m build
 rsync -av dist/ user:~/rapidfire
 
 # from directory where dist/ folder is
-pip install rapidfireai-0.9.10-py3-none-any.whl
+pip install rapidfireai-0.9.11-py3-none-any.whl
 
 export PATH="$HOME/.local/bin:$PATH"
 
 rapidfireai --version
-# RapidFire AI 0.9.10
+# RapidFire AI 0.9.11
 
 # install specific dependencies and initialize rapidfire
 rapidfireai init

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,22 @@ All notable changes `rapidfireai` will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## [v0.9.11]
+### Changes:
+* Add option to create a Test PyPI package
+* Added logging of rf version number in Experiment class's init method.
+* Do not install old version of flash-attn on NVIDIA 7 GPUs
+* Add RF_ prefix and accept existing values for MLFLOW_PORT, MLFLOW_HOST, FRONTEND_PORT, FRONTEND_HOST, API_PORT, API_HOST, PID_FILE
+* Allow use of RF_DB_PATH for DBConfig.DB_PATH in constants
+* Added lite versions of tutorial_notebooks that will run under 2 hours on T4 GPUs
+* rapidfireai init Copies tutorial notebooks to RF_TUTORIAL_PATH or ./tutorial_notebooks
+
+### Fixes:
+* Added checks in create_warm_start_checkpoint method in shm_manager.py. This method is only triggered during clone-modify warm start operations.
+* Creates mlflow.db file in RF_DB_PATH or ~/db
+* If netcat's nc not found rapidfireai start now falls back to a python port checker
+* rapidfireai start now tries python3/pip3 if possible then falls back to python/pip
+
 
 ## [v0.9.10]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rapidfireai"
-version = "0.9.10"
+version = "0.9.11"
 authors = [
     {name = "RapidFire AI Inc.", email = "support@rapidfire.ai"},
 ]

--- a/rapidfireai/version.py
+++ b/rapidfireai/version.py
@@ -2,5 +2,5 @@
 Version information for RapidFire AI
 """
 
-__version__ = "0.9.10"
-__version_info__ = (0, 9, 10) 
+__version__ = "0.9.11"
+__version_info__ = (0, 9, 11) 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# version 0.9.10
+# version 0.9.11
 
 # ml
 pandas>=2.3.1


### PR DESCRIPTION
## [v0.9.11]
### Changes:
* Add option to create a Test PyPI package
* Added logging of rf version number in Experiment class's init method.
* Do not install old version of flash-attn on NVIDIA 7 GPUs
* Add RF_ prefix and accept existing values for MLFLOW_PORT, MLFLOW_HOST, FRONTEND_PORT, FRONTEND_HOST, API_PORT, API_HOST, PID_FILE
* Allow use of RF_DB_PATH for DBConfig.DB_PATH in constants
* Added lite versions of tutorial_notebooks that will run under 2 hours on T4 GPUs
* rapidfireai init Copies tutorial notebooks to RF_TUTORIAL_PATH or ./tutorial_notebooks

### Fixes:
* Added checks in create_warm_start_checkpoint method in shm_manager.py. This method is only triggered during clone-modify warm start operations.
* Creates mlflow.db file in RF_DB_PATH or ~/db
* If netcat's nc not found rapidfireai start now falls back to a python port checker
* rapidfireai start now tries python3/pip3 if possible then falls back to python/pip