### PR TITLE
Controller: commented out SHM clear for deleted runs

### DIFF
--- a/rapidfireai/backend/controller.py
+++ b/rapidfireai/backend/controller.py
@@ -214,7 +214,9 @@ class Controller:
             elif run_state["status"] == RunStatus.DELETED:
                 # process deleted tasks
                 # clear run from shm
-                self._clear_run_from_shm(run_id)
+                # TODO: commented out to prevent clone of deleted runs issue (see Issue # 22)
+                # self._clear_run_from_shm(run_id)
+
                 # delete run from MLFlow
                 mlflow_run_id = self.db.get_run(run_id)["mlflow_run_id"]
                 self.mlflow_manager.delete_run(mlflow_run_id)


### PR DESCRIPTION
## Summary
This PR removes the clearing of runs from shared-memory(SHM) if that run has been deleted. We retain the run's details in SHM to be referenced at a later point by its clones (if any) as an when they are scheduled. Earlier we would run into issues where the clone would not find its parents details in shared memory, since the parent run had been deleted by the time the clone was scheduled to run (we access parent run's details from SHM only after a run has been scheduled).

Note: A more comprehensive fix is to fetch the run's details from disk if it has been cleared from shared memory, which will be taken up in future PRs.

This PR fixes [Issue 22 - IC-OP Clone and Delete on a same parent run ](https://github.com/RapidFireAI/rapidfireai/issues/22)

## Changes
- Commented out _clear_run_from_shm for deleted runs

## Testing
Tested E2E on SFT-Lite notebook, performing IC Ops Clone modify + delete.

## Screenshots
Runs 5 and 6 are clones of Run 3 which has been deleted. Runs 5 and 6 proceed to train without any errors.
<img width="1840" height="1214" alt="Screenshot 2025-09-16 at 12 24 51 AM" src="https://github.com/user-attachments/assets/684205d9-f93d-42a7-b914-1bf4aa37e003" />

<img width="4064" height="2334" alt="Screenshot 2025-09-16 at 12 23 50 AM" src="https://github.com/user-attachments/assets/3bee0328-e9a9-490c-8344-72e021fb1800" />
