### PR TITLE
Update versions of TRL and Torch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,10 +2,10 @@
 
 # ml
 pandas>=2.3.1
-torch>=2.8.0
+torch>=2.7.0
 transformers>=4.55.2
 peft>=0.17.0
-trl==0.21.0
+trl>=0.21.0
 bitsandbytes>=0.47.0
 nltk>=3.9.1
 evaluate>=0.4.5


### PR DESCRIPTION
# Summary
This PR unpins the TRL version requirement to >= 0.21.0 and PyTorch versions to >= 2.7.0

# Testing
Tested by running the SFT-Lite notebook E2E, with torch==2.7.0

# Screenshots
<img width="1840" height="1214" alt="Screenshot 2025-09-16 at 12 58 43 AM" src="https://github.com/user-attachments/assets/6846eaa9-2679-4542-9cfc-b8f8a7db1364" />
