### PR TITLE
Controller: fixed warm_start field

### DIFF
--- a/rapidfireai/backend/controller.py
+++ b/rapidfireai/backend/controller.py
@@ -276,7 +276,7 @@ class Controller:
                     clone_modify_info = {
                         "cloned_from": parent_run_id,
                         "start_chunk_id": parent_run_details["num_chunks_visited_curr_epoch"],
-                        "warm_started_from": parent_run_details["warm_started_from"],
+                        "warm_started_from": parent_run_id,
                     }
                     run_ids = self._create_models(
                         config_leaf,


### PR DESCRIPTION
# Summary
Fixed issue of warm-started runs not picking off from where it was cloned (at the parent).

# Changes
warm_started_from key was assigned a value that didn't exist. Updated it to hold the value of parent's run_id.

# Testing
Ran SFT Lite notebook E2E with ICOps Clone Modify with warm start.

# Screenshots
Shows Run 5(clone) having the same loss as Run1 (parent) at the point of cloning
<img width="4064" height="2334" alt="Screenshot 2025-09-16 at 6 38 03 PM" src="https://github.com/user-attachments/assets/3bdae766-d225-43a0-884c-4f997633f84b" />
Logs show warm start checkpoint being copied
<img width="4064" height="2334" alt="Screenshot 2025-09-16 at 6 39 01 PM" src="https://github.com/user-attachments/assets/792f3e09-ed8b-49fc-b2b8-2f33e6b90ef8" />

