### PR TITLE
bugfix/non-warm-start-clone datatype fix

### DIFF
--- a/rapidfireai/backend/controller.py
+++ b/rapidfireai/backend/controller.py
@@ -111,7 +111,7 @@ class Controller:
             # get clone modify info
             warm_started_from = clone_modify_info.get("warm_started_from") if clone_modify_info else None
             cloned_from = clone_modify_info.get("cloned_from") if clone_modify_info else None
-            chunk_offset = clone_modify_info.get("chunk_offset") if clone_modify_info else 0
+            chunk_offset = clone_modify_info.get("chunk_offset",0) if clone_modify_info else 0
 
             run_id = self.db.create_run(
                 config_leaf=config_leaf,
@@ -311,10 +311,11 @@ class Controller:
                     )
                 elif ic_op == ControllerTask.IC_CLONE_MODIFY_WARM:
                     # calculate clone chunk offset
+                    effective_batch_size = parent_run_details["config_leaf"]["training_args"].get("per_device_train_batch_size", 1) * parent_run_details["config_leaf"]["training_args"].get("gradient_accumulation_steps", 1)
                     chunker = DatasetChunks(
                         len_train_dataset,
                         num_chunks,
-                        batch_size=parent_run_details["config_leaf"]["training_args"]["per_device_train_batch_size"],
+                        batch_size=effective_batch_size,
                         offset=parent_run_details["chunk_offset"],
                     )
                     clone_chunk_offset = chunker.get_clone_offset(parent_run_details["num_chunks_visited_curr_epoch"])

--- a/rapidfireai/cli.py
+++ b/rapidfireai/cli.py
@@ -315,25 +315,26 @@ def install_packages():
     # else:
     #     print("\n⚠️  CUDA version not detected or unsupported.")
     
-    if cuda_major is not None:
-        print(f"\n🎯 Detected CUDA {cuda_major}.x")
+    ## TODO: re-enable once flash-attn has fix
+    # if cuda_major is not None:
+    #     print(f"\n🎯 Detected CUDA {cuda_major}.x")
         
-        # Determine flash-attn version based on CUDA version
-        if cuda_major < 8:
-            # flash-attn 1.x for CUDA < 8.0
-            print("Installing latest flash-attn 1.x for CUDA < 8.0")
-            packages.append({"package": "flash-attn<2.0", "extra_args": ["--no-build-isolation"]})
-        elif cuda_major == 9:
-            # flash-attn 3.x for CUDA 9.0 specifically
-            print("Installing latest flash-attn 3.x for CUDA 9.0")
-            packages.append({"package": "flash-attn>=3.0,<4.0", "extra_args": ["--no-build-isolation"]})
-        elif cuda_major >= 8:
-            # flash-attn 2.x for CUDA >= 8.0 (but not 9.0)
-            print("Installing flash-attn 2.8.3 for CUDA >= 8.0")
-            packages.append({"package": "flash-attn==2.8.3", "extra_args": ["--no-build-isolation"]})
-    else:
-        print("\n⚠️  CUDA version not detected.")
-        print("Skipping flash-attn installation")
+    #     # Determine flash-attn version based on CUDA version
+    #     if cuda_major < 8:
+    #         # flash-attn 1.x for CUDA < 8.0
+    #         print("Installing latest flash-attn 1.x for CUDA < 8.0")
+    #         packages.append({"package": "flash-attn<2.0", "extra_args": ["--no-build-isolation"]})
+    #     elif cuda_major == 9:
+    #         # flash-attn 3.x for CUDA 9.0 specifically
+    #         print("Installing latest flash-attn 3.x for CUDA 9.0")
+    #         packages.append({"package": "flash-attn>=3.0,<4.0", "extra_args": ["--no-build-isolation"]})
+    #     elif cuda_major >= 8:
+    #         # flash-attn 2.x for CUDA >= 8.0 (but not 9.0)
+    #         print("Installing flash-attn 2.8.3 for CUDA >= 8.0")
+    #         packages.append({"package": "flash-attn==2.8.3", "extra_args": ["--no-build-isolation"]})
+    # else:
+    #     print("\n⚠️  CUDA version not detected.")
+    #     print("Skipping flash-attn installation")
 
     for package_info in packages:
         try:

--- a/tutorial_notebooks/rf-tutorial-grpo-mathreasoning-lite.ipynb
+++ b/tutorial_notebooks/rf-tutorial-grpo-mathreasoning-lite.ipynb
@@ -207,7 +207,7 @@
     "    gradient_accumulation_steps=2,\n",
     "    num_generations=8,\n",
     "    optim =\"adamw_8bit\",\n",
-    "    num_train_epochs=3,\n",
+    "    num_train_epochs=1,\n",
     "    max_prompt_length=256,\n",
     "    max_completion_length=256,\n",
     "    logging_steps=2,\n",
@@ -330,7 +330,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "lite",
+   "display_name": ".venv",
    "language": "python",
    "name": "python3"
   },


### PR DESCRIPTION
### Summary

- Resolved datatype error bug that was causing non-warm start ICOps clone operations to fail
- Disabled flash attention that was causing cuda re-initialization, forcing all runs to happen on same GPU:0 on H100s

### Changes
1. Fixed datatype issue in controller.py by setting default value to 0 
2. Disabled flash attention package dependency by commenting it out in cli.py
3. Modified GRPO-lite notebook to run for only 1 epoch instead of 3

### Testing
Tested end to end on all lite notebooks and regular notebooks with downsampled data

### Screenshots
Generated plots for non-warm start ICOps clone functionality, confirming the fix works as expected
[
<img width="1470" height="956" alt="Screenshot 2025-09-20 at 2 47 22 PM" src="https://github.com/user-attachments/assets/c6d2f203-c177-42da-a8b7-57e5c3cd4387" />
](url)
