### PR TITLE
Clean embedded outputs from Colab TensorBoard tutorial notebook

### DIFF
--- a/tutorial_notebooks/rf-colab-tensorboard-tutorial.ipynb
+++ b/tutorial_notebooks/rf-colab-tensorboard-tutorial.ipynb
@@ -51,7 +51,7 @@
         "pip install rapidfireai # Takes 1 min\n",
         "rapidfireai init # Takes 1 min\n",
         "export RF_TRACKING_BACKEND=tensorboard\n",
-        "rapidfireai start --colab # Takes 0.5 min\n",
+        "rapidfireai start --colab & # Takes 0.5 min\n",
         "```\n",
         "\n",
         "The `--colab` flag will:\n",
@@ -606,21 +606,12 @@
       "source": [
         "# View RapidFire AI Log Files\n",
         "\n",
-        "You can track the work being done by the system via the RapidFire AI-produced log files:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "3OxApW7jWeLw"
-      },
-      "outputs": [],
-      "source": [
-        "!ls\n",
-        "!ls rapidfire_experiments/\n",
-        "!tail -n 20 rapidfire_experiments/rapidfire.log\n",
-        "!tail -n 20 rapidfire_experiments/training.log"
+        "You can track the work being done by the system via the RapidFire AI-produced log files in rapidfire_experiments/ folder. To see the log files, open the Colab terminal and run the commands:\n",
+        "\n",
+        "```bash\n",
+        "tail -n 20 rapidfire_experiments/rapidfire.log\n",
+        "tail -n 20 rapidfire_experiments/training.log\n",
+        "```"
       ]
     }
   ],


### PR DESCRIPTION
## Changes
- Remove ~18MB of embedded TensorBoard visualization data from Colab metadata that was accidentally committed. The notebook now contains only code and markdown cells without execution outputs.
- Keep the Colab terminal available by putting the "rapidfireai start" command in the background using '&' op. 
- Clarify the instruction explaining how to find and view the log files (rapidfire.log and training.log)

File size reduced from 18.2MB to 21KB (99.89% reduction).

## Testing
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have tested this change manually
- [ ] I have tested this change in the following environments:
  - [ ] Local development
  - [ ] Docker environment
  - [ ] Other: _______________

## Screenshots (if applicable)
Add screenshots to help explain your changes.

## Checklist
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Performance Impact
If this PR affects performance, describe the impact and any optimizations made.

## Related Issues
Fixes #74 
Closes #(issue number)
Related to #(issue number)
