### PR TITLE
reverted colab sft notebook to 0.11.1 api and port

### DIFF
--- a/tutorial_notebooks/fine-tuning/rf-colab-tensorboard-tutorial.ipynb
+++ b/tutorial_notebooks/fine-tuning/rf-colab-tensorboard-tutorial.ipynb
@@ -152,7 +152,7 @@
    "outputs": [],
    "source": [
     "from rapidfireai import Experiment\n",
-    "from rapidfireai.fit.automl import List, RFGridSearch, RFModelConfig, RFLoraConfig, RFSFTConfig"
+    "from rapidfireai.automl import List, RFGridSearch, RFModelConfig, RFLoraConfig, RFSFTConfig"
    ]
   },
   {
@@ -278,7 +278,7 @@
    "source": [
     "# Create experiment with unique name\n",
     "my_experiment = \"tensorboard-demo-1\"\n",
-    "experiment = Experiment(experiment_name=my_experiment, mode=\"fit\")"
+    "experiment = Experiment(experiment_name=my_experiment)"
    ]
   },
   {
@@ -301,7 +301,7 @@
    "outputs": [],
    "source": [
     "# Get experiment path\n",
-    "from rapidfireai.fit.db.rf_db import RfDb\n",
+    "from rapidfireai.db.rf_db import RfDb\n",
     "\n",
     "db = RfDb()\n",
     "experiment_path = db.get_experiments_path(my_experiment)\n",
@@ -497,9 +497,9 @@
    "outputs": [],
    "source": [
     "# Create Interactive Controller\n",
-    "from rapidfireai.fit.utils.interactive_controller import InteractiveController\n",
+    "from rapidfireai.utils.interactive_controller import InteractiveController\n",
     "\n",
-    "controller = InteractiveController(dispatcher_url=\"http://127.0.0.1:8851\")\n",
+    "controller = InteractiveController(dispatcher_url=\"http://127.0.0.1:8081\")\n",
     "controller.display()"
    ]
   },


### PR DESCRIPTION
## Changes
- revereted sft lite colab notebook to api and port of previously fully working 0.11.1

## Testing
- [x] I have tested this change manually
- [x] I have tested this change in the following environments:
  - [x] Other: On Colab

## Screenshots (if applicable)
<img width="1497" height="754" alt="Screenshot 2025-11-11 at 6 32 34 PM" src="https://github.com/user-attachments/assets/1f6e7911-ab03-42c2-9e1b-f7e936c089ab" />
<img width="1502" height="777" alt="Screenshot 2025-11-11 at 6 33 12 PM" src="https://github.com/user-attachments/assets/3ed79524-8906-4723-b3bd-7a90ce5ef218" />

