### PR TITLE
Feature/results to df

### DIFF
--- a/rapidfireai/evals/scheduling/controller.py
+++ b/rapidfireai/evals/scheduling/controller.py
@@ -4,7 +4,6 @@ import time
 from collections.abc import Callable
 from typing import Any
 
-import pandas as pd
 import ray
 
 from rapidfireai.evals.actors.doc_actor import DocProcessingActor
@@ -506,6 +505,7 @@ class Controller:
         pipeline_results: dict[int, dict],
         db: RFDatabase,
         progress_display=None,
+        pipeline_id_to_info: dict[int, dict] = None,
     ) -> dict[int, tuple[dict, dict]]:
         """
         Compute final metrics for each pipeline and update database.
@@ -517,6 +517,7 @@ class Controller:
             pipeline_results: Mapping of pipeline_id to results/metrics dict
             db: Database instance
             progress_display: Optional progress display to update
+            pipeline_id_to_info: Optional mapping of pipeline_id to pipeline info dict
 
         Returns:
             Dict mapping pipeline_id to (aggregated_results, cumulative_metrics)
@@ -572,30 +573,46 @@ class Controller:
                     cumulative_metrics, samples_processed
                 )
 
+            # Add pipeline info to cumulative_metrics (use passed pipeline_id_to_info if available)
+            if pipeline_id_to_info and pipeline_id in pipeline_id_to_info:
+                pipeline_info_dict = pipeline_id_to_info[pipeline_id]
+                for key, value in pipeline_info_dict.items():
+                    cumulative_metrics[key] = {"value": value}
+
+            # Reorder cumulative_metrics: run_id, model_name, hyperparams, Samples Processed, then metrics
+            ordered_metrics = {}
+            
+            ordered_metrics["run_id"] = {"value": pipeline_id}
+            
+            if "model_name" in cumulative_metrics:
+                ordered_metrics["model_name"] = cumulative_metrics["model_name"]
+            
+            hyperparam_keys = ["search_type", "rag_k", "top_n", "chunk_size", "chunk_overlap", 
+                             "sampling_params", "prompt_manager_k", "model_config"]
+            for key in hyperparam_keys:
+                if key in cumulative_metrics:
+                    ordered_metrics[key] = cumulative_metrics[key]
+            
+            if "Samples Processed" in cumulative_metrics:
+                ordered_metrics["Samples Processed"] = cumulative_metrics["Samples Processed"]
+            
+            excluded_keys = {"run_id", "model_name", "Samples Processed"} | set(hyperparam_keys)
+            for key, value in cumulative_metrics.items():
+                if key not in excluded_keys:
+                    ordered_metrics[key] = value
+
             final_results[pipeline_id] = (
                 pipeline_results[pipeline_id]["results"],
-                cumulative_metrics,
+                ordered_metrics,
             )
 
             # Update pipeline status
             db.set_pipeline_status(pipeline_id, PipelineStatus.COMPLETED)
             if progress_display:
                 # Update display with final metrics to ensure all metrics are shown
-                # Add confidence intervals to final metrics if online strategy is available
-                samples_processed = sum(
-                    m.get("value", 0)
-                    for m in pipeline_results[pipeline_id]["metrics"].get("Samples Processed", [{}])
-                )
-                if aggregator.online_strategy and samples_processed > 0:
-                    metrics_with_ci = aggregator.online_strategy.add_confidence_interval_info(
-                        cumulative_metrics, samples_processed
-                    )
-                else:
-                    metrics_with_ci = cumulative_metrics
-
-                # Convert cumulative_metrics format to display format with CI info
+                # Convert ordered_metrics format to display format with CI info
                 display_metrics = {}
-                for metric_name, metric_data in metrics_with_ci.items():
+                for metric_name, metric_data in ordered_metrics.items():
                     if isinstance(metric_data, dict):
                         display_metrics[metric_name] = {
                             "value": metric_data.get("value", 0),
@@ -618,40 +635,6 @@ class Controller:
             progress_display.stop()
         return final_results
 
-    def _convert_results_to_dataframe(
-        self,
-        final_results: dict[int, tuple[dict, dict]],
-        pipeline_id_to_config: dict[int, dict],
-    ) -> pd.DataFrame:
-        """
-        Returns:
-            DataFrame with one row per pipeline configuration
-        """
-        rows = []
-
-        for pipeline_id, (aggregated_results, cumulative_metrics) in final_results.items():
-            pipeline_config = pipeline_id_to_config.get(pipeline_id, {})
-            pipeline_name = pipeline_config.get("pipeline_name", f"Pipeline {pipeline_id}")
-
-            row = {
-                "pipeline_id": pipeline_id,
-            }
-
-            for metric_name, metric_data in cumulative_metrics.items():
-                if isinstance(metric_data, dict):
-                    row[metric_name] = metric_data.get("value")
-                else:
-                    row[metric_name] = metric_data
-
-            rows.append(row)
-
-        df = pd.DataFrame(rows)
-
-        if not df.empty:
-            df = df.sort_values("pipeline_id").reset_index(drop=True)
-
-        return df
-
     def run_multi_pipeline_inference(
         self,
         experiment_id: int,
@@ -662,7 +645,7 @@ class Controller:
         num_actors: int = None,
         num_gpus: int = None,
         num_cpus: int = None,
-    ) -> pd.DataFrame:
+    ) -> dict[int, tuple[dict, dict]]:
         """
         Run multi-pipeline inference with fair round-robin scheduling.
 
@@ -1214,6 +1197,12 @@ class Controller:
             db.set_pipeline_current_shard(pipeline_id, shard_id)
 
         # PHASE 8: Compute final metrics for each pipeline
+        pipeline_id_to_info = {}
+        for info_dict in pipeline_info:
+            pipeline_id = info_dict["pipeline_id"]
+            info_copy = {k: v for k, v in info_dict.items() if k not in ["pipeline_config", "pipeline_id"]}
+            pipeline_id_to_info[pipeline_id] = info_copy
+        
         final_results = self._compute_final_metrics_for_pipelines(
             pipeline_ids,
             pipeline_id_to_config,
@@ -1221,12 +1210,12 @@ class Controller:
             pipeline_results,
             db,
             progress_display,
+            pipeline_id_to_info,
         )
+
 
         # Cleanup actors
         for actor in query_actors:
             ray.kill(actor)
 
-        results_df = self._convert_results_to_dataframe(final_results, pipeline_id_to_config)
-
-        return results_df
+        return final_results

--- a/tutorial_notebooks/rag-contexteng/rf-tutorial-gsm8k-fewshot.ipynb
+++ b/tutorial_notebooks/rag-contexteng/rf-tutorial-gsm8k-fewshot.ipynb
@@ -402,7 +402,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "results"
+    "# Convert results dict to DataFrame\n",
+    "results_df = pd.DataFrame([\n",
+    "    {k: v['value'] if isinstance(v, dict) and 'value' in v else v for k, v in {**metrics_dict, 'run_id': run_id}.items()}\n",
+    "    for run_id, (_, metrics_dict) in results.items()\n",
+    "])\n",
+    "\n",
+    "results_df"
    ]
   },
   {

--- a/tutorial_notebooks/rag-contexteng/rf-tutorial-rag-fiqa.ipynb
+++ b/tutorial_notebooks/rag-contexteng/rf-tutorial-rag-fiqa.ipynb
@@ -451,11 +451,17 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "57d4926a",
+   "id": "127e7b4a",
    "metadata": {},
    "outputs": [],
    "source": [
-    "results"
+    "# Convert results dict to DataFrame\n",
+    "results_df = pd.DataFrame([\n",
+    "    {k: v['value'] if isinstance(v, dict) and 'value' in v else v for k, v in {**metrics_dict, 'run_id': run_id}.items()}\n",
+    "    for run_id, (_, metrics_dict) in results.items()\n",
+    "])\n",
+    "\n",
+    "results_df"
    ]
   },
   {

--- a/tutorial_notebooks/rag-contexteng/rf-tutorial-scifact-full-evaluation.ipynb
+++ b/tutorial_notebooks/rag-contexteng/rf-tutorial-scifact-full-evaluation.ipynb
@@ -504,7 +504,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "results"
+    "# Convert results dict to DataFrame\n",
+    "results_df = pd.DataFrame([\n",
+    "    {k: v['value'] if isinstance(v, dict) and 'value' in v else v for k, v in {**metrics_dict, 'run_id': run_id}.items()}\n",
+    "    for run_id, (_, metrics_dict) in results.items()\n",
+    "])\n",
+    "\n",
+    "results_df"
    ]
   },
   {


### PR DESCRIPTION
## Changes
- updated notebooks to display dataframe from the results dict
- Added other experimentation knobs to the results dict

## Testing
- Tested on all three notebooks with downsampled data and just 2 configs 


## Screenshots

a. hyrbid - gsm8k:
<img width="1207" height="334" alt="Screenshot 2025-11-13 at 3 47 50 PM" src="https://github.com/user-attachments/assets/c3d4315e-6c35-4057-8552-b48904569929" />



b. Fully openai - scifact:(couldn't screenshot the full df)
<img width="1203" height="306" alt="Screenshot 2025-11-13 at 3 52 35 PM" src="https://github.com/user-attachments/assets/2dfadf42-49e4-48a7-92c1-9fcc612b15f9" />



c. Fully Local: fiqa
<img width="1187" height="148" alt="Screenshot 2025-11-13 at 3 41 28 PM" src="https://github.com/user-attachments/assets/ab25efe6-83ba-4186-bd63-735f28923205" />
<img width="1205" height="161" alt="Screenshot 2025-11-13 at 3 41 31 PM" src="https://github.com/user-attachments/assets/3539b175-39c8-4287-b53b-2b2fc0583ea6" />




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds pipeline metadata to final metrics with consistent ordering and updates tutorials to display results as a DataFrame.
> 
> - **Evals Controller (`rapidfireai/evals/scheduling/controller.py`)**:
>   - *Final metrics pipeline*: `_compute_final_metrics_for_pipelines` now accepts optional `pipeline_id_to_info` and injects pipeline metadata (e.g., `model_name`, `search_type`, `rag_k`, `top_n`, `chunk_size`, `chunk_overlap`, `sampling_params`, `prompt_manager_k`, `model_config`).
>   - *Ordering and output*: Reorders cumulative metrics to `run_id`, `model_name`, hyperparams, `Samples Processed`, then remaining metrics; returns `ordered_metrics` and uses it for progress display.
>   - *Integration*: Builds `pipeline_id_to_info` from `pipeline_info` and passes it to final-metrics computation.
> - **Tutorial Notebooks**:
>   - Replace sample printouts with conversion of `results` into a pandas DataFrame (`results_df`) in `rf-tutorial-gsm8k-fewshot.ipynb`, `rf-tutorial-rag-fiqa.ipynb`, and `rf-tutorial-scifact-full-evaluation.ipynb`.
>   - Minor notebook metadata/formatting tweaks (ids, kernelspec).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit efdc97980b9a90ea51f9e849c45dea8dd1d8be70. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->