### PR TITLE
fix: Restore broken HuggingFace documentation links

### DIFF
--- a/tutorial_notebooks/rf-tutorial-dpo-alignment-lite.ipynb
+++ b/tutorial_notebooks/rf-tutorial-dpo-alignment-lite.ipynb
@@ -1,0 +1,442 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a4bdc828",
+   "metadata": {},
+   "source": [
+    "<div align=\"center\">\n",
+    "<a href=\"https://rapidfire.ai/\"><img src=\"https://raw.githubusercontent.com/RapidFireAI/rapidfireai/main/docs/images/RapidFire - Blue bug -white text.svg\" width=\"115\"></a>\n",
+    "<a href=\"https://discord.gg/6vSTtncKNN\"><img src=\"https://raw.githubusercontent.com/RapidFireAI/rapidfireai/main/docs/images/discord-button.svg\" width=\"145\"></a>\n",
+    "<a href=\"https://oss-docs.rapidfire.ai/\"><img src=\"https://raw.githubusercontent.com/RapidFireAI/rapidfireai/main/docs/images/documentation-button.svg\" width=\"125\"></a>\n",
+    "<br/>\n",
+    "Join Discord if you need help + ⭐ <i>Star us on <a href=\"https://github.com/RapidFireAI/rapidfireai\">GitHub</a></i> ⭐\n",
+    "<br/>\n",
+    "To install RapidFire AI on your own machine, see the <a href=\"https://oss-docs.rapidfire.ai/en/latest/walkthrough.html\">Install and Get Started</a> guide in our docs.\n",
+    "</div>\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "668ecb93",
+   "metadata": {},
+   "source": [
+    "### RapidFire AI Tutorial Use Case: DPO for Alignment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bb9cb2b3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from rapidfireai import Experiment\n",
+    "from rapidfireai.fit.automl import List, RFGridSearch, RFModelConfig, RFLoraConfig, RFDPOConfig"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9bb751f2",
+   "metadata": {},
+   "source": [
+    "### Load Dataset and Sample Train Subset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e4c3655f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datasets import load_dataset\n",
+    "\n",
+    "# Select a subset of the dataset for demo purposes\n",
+    "train_dataset = load_dataset(\n",
+    "    \"trl-lib/ultrafeedback_binarized\", \n",
+    "    split=\"train\").select(range(128))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2485d399",
+   "metadata": {},
+   "source": [
+    "### Initialize Experiment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cf47412f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Every experiment instance must be uniquely named\n",
+    "experiment = Experiment(experiment_name=\"exp1-sft-dpo-lite\", mode=\"fit\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3378be4c",
+   "metadata": {},
+   "source": [
+    "#### Direct Preference Optimization (DPO) Training \n",
+    "\n",
+    "The first step is to train a **Supervised Fine-Tuning (SFT)** model to ensure the data we train on is in-distribution for the DPO algorithm.\n",
+    "\n",
+    "Fine-tuning a language model via DPO consists of **two steps** and is significantly easier than PPO:\n",
+    "\n",
+    "1. Data Collection: Gather a preference dataset containing:\n",
+    "    - **Positive examples**: High-quality generations given a prompt\n",
+    "    - **Negative examples**: Lower-quality generations for the same prompt\n",
+    "    - **Paired comparisons**: Each prompt has both chosen and rejected responses\n",
+    "\n",
+    "2. Optimization: Maximize the log-likelihood of the DPO loss directly.\n",
+    "\n",
+    "Since our goal is to demonstrate DPO, we will assume you already have **pretrained model or adapters from SFT training** and use them as our starting point."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "51df13d9",
+   "metadata": {},
+   "source": [
+    "### Model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "abbbd1f3",
+   "metadata": {},
+   "source": [
+    "##### Quantization and LoRA Config"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c46f0565",
+   "metadata": {},
+   "source": [
+    "We supervised fine-tuned (QLoRA) the `mistralai/Mistral-7B-Instruct-v0.3` base model by using preferred completions for supervision from the `trl-lib/ultrafeedback_binarized`. This ensures that the output paths sampled during the alignment training already exist in the model's distribution. We do not want the model to have to learn a new task from ground up during the alignment training. The goal of DPO training is to achieve alignment with human preferences by contrastively learning which outputs are considered preferred and which ones are dispreferred.\n",
+    "\n",
+    "The quantization config for `rapidfire-ai-inc/mistral-7b-sft-bnb-4bit` is below:\n",
+    "```python\n",
+    "bnb_config = BitsAndBytesConfig(\n",
+    "    load_in_4bit=True,\n",
+    "    bnb_4bit_compute_dtype=torch.bfloat16,\n",
+    "    bnb_4bit_use_double_quant=True,\n",
+    "    bnb_4bit_quant_type=\"nf4\",\n",
+    ")\n",
+    "```\n",
+    "We will use QLoRA to further fine-tune the SFT model for alignment with DPO"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0ac53010",
+   "metadata": {},
+   "source": [
+    "### Define Multi-Config Knobs for Model, LoRA, and DPO Trainer using RapidFire AI Wrapper APIs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "11960e7a",
+   "metadata": {},
+   "source": [
+    "We create a common base config, since most of the knobs will remain same across the configs in our experiment."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "af5aab6b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from peft import TaskType\n",
+    "\n",
+    "MODEL_NAME_OR_PATH = \"rapidfire-ai-inc/mistral-7b-sft-bnb-4bit\"\n",
+    "\n",
+    "base_lora_config_lite = RFLoraConfig(\n",
+    "    task_type=TaskType.CAUSAL_LM,\n",
+    "    r=64, \n",
+    "    lora_alpha=64, \n",
+    "    lora_dropout=0.1, \n",
+    "    target_modules=[\"q_proj\", \"k_proj\", \"v_proj\", \"o_proj\", \"gate_proj\", \"up_proj\", \"down_proj\"],\n",
+    "    bias=\"none\", \n",
+    ")\n",
+    "\n",
+    "base_dpo_config_lite = RFDPOConfig(\n",
+    "    gradient_checkpointing=True,\n",
+    "    gradient_checkpointing_kwargs={\"use_reentrant\": True},\n",
+    "    model_adapter_name=\"default\", # LoRA Adapter from original SFT trained model, if any. This adapter will be trained using DPO.\n",
+    "    ref_adapter_name=\"reference\", # LoRA Adapter from original SFT trained model, if any. This adapter will remain unchanged and will be used for reference model.\n",
+    "    force_use_ref_model=False, \n",
+    "    loss_type=\"sigmoid\", # Uses Bradley-Terry model to calculate the loss.\n",
+    "    beta=0.1, \n",
+    "    max_prompt_length=512,\n",
+    "    max_completion_length=512,\n",
+    "    max_length=1024, # Prompt + completion\n",
+    "    per_device_train_batch_size=2,\n",
+    "    gradient_accumulation_steps=2,\n",
+    "    learning_rate=5e-4,\n",
+    "    warmup_ratio=0.1,\n",
+    "    weight_decay=0,\n",
+    "    lr_scheduler_type=\"linear\",\n",
+    "    num_train_epochs=1, \n",
+    "    optim=\"adamw_8bit\",\n",
+    "    bf16=True,\n",
+    "    save_strategy=\"epoch\",\n",
+    "    logging_strategy=\"steps\",\n",
+    "    logging_steps=1\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0d8d056c",
+   "metadata": {},
+   "source": [
+    "Now we create 3 different configs for experimentation by cloning the base config and only modifying the knobs we need."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3f7c2957",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Config 1 - Basic Bradley-Terry model with medium LoRA and large beta\n",
+    "lora_config_1 = base_lora_config_lite.copy()\n",
+    "lora_config_1.r = 16\n",
+    "lora_config_1.lora_alpha = 16\n",
+    "\n",
+    "dpo_config_1 = base_dpo_config_lite.copy()\n",
+    "dpo_config_1.loss_type = \"sigmoid\"\n",
+    "dpo_config_1.beta = 0.1\n",
+    "\n",
+    "# Config 2 - Assumes noisy preference data, use label smoothing to handle it with Robust loss\n",
+    "lora_config_2 = base_lora_config_lite.copy()\n",
+    "lora_config_2.r = 16\n",
+    "lora_config_2.lora_alpha = 16\n",
+    "\n",
+    "dpo_config_2 = base_dpo_config_lite.copy()\n",
+    "dpo_config_2.loss_type = \"robust\"\n",
+    "dpo_config_2.beta = 0.1\n",
+    "dpo_config_2.label_smoothing = 0.5\n",
+    "\n",
+    "# Config 3 - Use a combined loss function with weighted sum\n",
+    "lora_config_3 = base_lora_config_lite.copy()\n",
+    "lora_config_3.r = 16\n",
+    "lora_config_3.lora_alpha = 16\n",
+    "\n",
+    "dpo_config_3 = base_dpo_config_lite.copy()\n",
+    "dpo_config_3.loss_type = [\"sigmoid\", \"bco_pair\", \"sft\"]\n",
+    "dpo_config_3.loss_weights = [0.8, 0.2, 1.0]\n",
+    "dpo_config_3.beta = 0.1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5992c776",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "\n",
+    "# List of 3 separate configs\n",
+    "config_set = List([\n",
+    "    RFModelConfig(\n",
+    "        model_name=MODEL_NAME_OR_PATH,\n",
+    "        ref_model_name=None,\n",
+    "        peft_config=lora_config_1,\n",
+    "        training_args=dpo_config_1,\n",
+    "        model_kwargs={\"device_map\": \"auto\", \"torch_dtype\": torch.bfloat16},\n",
+    "        tokenizer_kwargs={\"model_max_length\": 1024, \"padding_side\": \"left\", \"truncation\": True}\n",
+    "    ),\n",
+    "    RFModelConfig(\n",
+    "        model_name=MODEL_NAME_OR_PATH,\n",
+    "        ref_model_name=None,\n",
+    "        peft_config=lora_config_2,\n",
+    "        training_args=dpo_config_2,\n",
+    "        model_kwargs={ \"device_map\": \"auto\", \"torch_dtype\": torch.bfloat16},\n",
+    "        tokenizer_kwargs={\"model_max_length\": 1024, \"padding_side\": \"left\", \"truncation\": True}\n",
+    "    ),\n",
+    "    RFModelConfig(\n",
+    "        model_name=MODEL_NAME_OR_PATH,\n",
+    "        ref_model_name=None,\n",
+    "        peft_config=lora_config_3,\n",
+    "        training_args=dpo_config_3,\n",
+    "        model_kwargs={ \"device_map\": \"auto\", \"torch_dtype\": torch.bfloat16},\n",
+    "        tokenizer_kwargs={\"model_max_length\": 1024, \"padding_side\": \"left\", \"truncation\": True}\n",
+    "    )\n",
+    "])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b02f3152",
+   "metadata": {},
+   "source": [
+    "#### Define Model Creation Function"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1854ddf0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def sample_create_model(model_config): \n",
+    "   \"\"\"Function to create model object for any given config; must return tuple of (model, tokenizer)\"\"\"\n",
+    "   from transformers import AutoModelForCausalLM, AutoTokenizer\n",
+    "\n",
+    "   model = AutoModelForCausalLM.from_pretrained(\n",
+    "      model_config[\"model_name\"], \n",
+    "      **model_config[\"model_kwargs\"]\n",
+    "   )\n",
+    "   model.config.use_cache = False # Disable caching to save memory and stability during training\n",
+    "\n",
+    "   tokenizer = AutoTokenizer.from_pretrained(\n",
+    "      model_config[\"model_name\"], \n",
+    "      **model_config[\"tokenizer_kwargs\"]\n",
+    "   )\n",
+    "   if tokenizer.pad_token is None:\n",
+    "      tokenizer.pad_token = tokenizer.eos_token\n",
+    "\n",
+    "   return (model, tokenizer)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "abf1feb4",
+   "metadata": {},
+   "source": [
+    "#### Generate Config Group"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7c2402aa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Simple grid search across all sets of config knob values = 3 combinations in total\n",
+    "config_group = RFGridSearch(\n",
+    "    configs=config_set,\n",
+    "    trainer_type=\"DPO\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d0f3d1ab",
+   "metadata": {},
+   "source": [
+    "### Run Multi-Config Training"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b2cc2c0d",
+   "metadata": {},
+   "source": [
+    "##### DPO Training Metrics\n",
+    "\n",
+    "During training and evaluation, we track the following reward metrics:\n",
+    "\n",
+    "| Metric | Description |\n",
+    "|--------|-------------|\n",
+    "| `rewards/chosen` | Mean difference between policy and reference model log probabilities for chosen responses (scaled by β) |\n",
+    "| `rewards/rejected` | Mean difference between policy and reference model log probabilities for rejected responses (scaled by β) |\n",
+    "| `rewards/accuracies` | Percentage of cases where chosen rewards > rejected rewards |\n",
+    "| `rewards/margins` | Mean difference between chosen and rejected rewards |\n",
+    "\n",
+    "##### Mathematical Representation\n",
+    "\n",
+    "- **Chosen Rewards**: $\\beta * (\\log \\pi_\\theta(y_w|x) - \\log \\pi_{ref}(y_w|x))$\n",
+    "- **Rejected Rewards**: $\\beta * (\\log \\pi_\\theta(y_l|x) - \\log \\pi_{ref}(y_l|x))$\n",
+    "- **Accuracy**: $\\mathbb{E}[\\mathbf{1}[r_{chosen} > r_{rejected}]]$\n",
+    "- **Margin**: $\\mathbb{E}[r_{chosen} - r_{rejected}]$\n",
+    "\n",
+    "Where:\n",
+    "- $\\pi_\\theta$ = policy model\n",
+    "- $\\pi_{ref}$ = reference model  \n",
+    "- $y_w$ = chosen (winning) response\n",
+    "- $y_l$ = rejected (losing) response\n",
+    "- $\\beta$ = temperature parameter"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e8c2dcad",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Launch training of all configs in the config_group with swap granularity of 3 chunks\n",
+    "experiment.run_fit(config_group, sample_create_model, train_dataset, eval_dataset=None, num_chunks=4, seed=42)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4b0a81b9",
+   "metadata": {},
+   "source": [
+    "### End Current Experiment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e85f16ee",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "experiment.end()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b9d45914",
+   "metadata": {},
+   "source": [
+    "<div align=\"center\">\n",
+    "<a href=\"https://rapidfire.ai/\"><img src=\"https://raw.githubusercontent.com/RapidFireAI/rapidfireai/main/docs/images/RapidFire - Blue bug -white text.svg\" width=\"115\"></a>\n",
+    "<a href=\"https://discord.gg/6vSTtncKNN\"><img src=\"https://raw.githubusercontent.com/RapidFireAI/rapidfireai/main/docs/images/discord-button.svg\" width=\"145\"></a>\n",
+    "<a href=\"https://oss-docs.rapidfire.ai/\"><img src=\"https://raw.githubusercontent.com/RapidFireAI/rapidfireai/main/docs/images/documentation-button.svg\" width=\"125\"></a>\n",
+    "<br/>\n",
+    "Thanks for trying RapidFire AI! ⭐ <i>Star us on <a href=\"https://github.com/RapidFireAI/rapidfireai\">GitHub</a></i> ⭐\n",
+    "</div>"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "lite",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tutorial_notebooks/rf-tutorial-grpo-mathreasoning-lite.ipynb
+++ b/tutorial_notebooks/rf-tutorial-grpo-mathreasoning-lite.ipynb
@@ -1,0 +1,380 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div align=\"center\">\n",
+    "<a href=\"https://rapidfire.ai/\"><img src=\"https://raw.githubusercontent.com/RapidFireAI/rapidfireai/main/doc/images/RapidFire - Blue bug -white text.svg\" width=\"115\"></a>\n",
+    "<a href=\"https://discord.gg/6vSTtncKNN\"><img src=\"https://raw.githubusercontent.com/RapidFireAI/rapidfireai/main/doc/images/discord-button.svg\" width=\"145\"></a>\n",
+    "<a href=\"https://oss-docs.rapidfire.ai/\"><img src=\"https://raw.githubusercontent.com/RapidFireAI/rapidfireai/main/doc/images/documentation-button.svg\" width=\"125\"></a>\n",
+    "<br/>\n",
+    "Join Discord if you need help + \u2b50 <i>Star us on <a href=\"https://github.com/RapidFireAI/rapidfireai\">GitHub</a></i> \u2b50\n",
+    "<br/>\n",
+    "To install RapidFire AI on your own machine, see the <a href=\"https://oss-docs.rapidfire.ai/en/latest/walkthrough.html\">Install and Get Started</a> guide in our docs.\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### RapidFire AI Tutorial Use Case: GRPO for Math Reasoning"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from rapidfireai import Experiment\n",
+    "from rapidfireai.fit.automl import List, RFGridSearch, RFModelConfig, RFLoraConfig, RFGRPOConfig"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Load Dataset and Specify Train and Eval Partitions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datasets import load_dataset, Dataset\n",
+    "\n",
+    "def get_gsm8k_questions(split = \"train\") -> Dataset:\n",
+    "    data = load_dataset('openai/gsm8k', 'main')[split] \n",
+    "    return data \n",
+    "\n",
+    "# Select a subset of the dataset for demo purposes\n",
+    "train_dataset = get_gsm8k_questions(split=\"train\").select(range(128))\n",
+    "eval_dataset = get_gsm8k_questions(split=\"test\").select(range(24))\n",
+    "train_dataset = train_dataset.shuffle(seed=42)\n",
+    "eval_dataset =  eval_dataset.shuffle(seed=42)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Define Data Processing Function"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def sample_formatting_function(row):\n",
+    "    \"\"\"Function to preprocess each example from dataset\"\"\"\n",
+    "\n",
+    "    def extract_hash_answer(text: str) -> str | None:\n",
+    "        if \"####\" not in text:\n",
+    "            return None\n",
+    "        answer = text.split(\"####\")[1].strip()\n",
+    "        try:\n",
+    "            answer = answer.replace(\",\", \"\")\n",
+    "        except:\n",
+    "            return None\n",
+    "        return answer\n",
+    "        \n",
+    "    SYSTEM_PROMPT = \"\"\"\n",
+    "    Respond in the following format:\n",
+    "    <reasoning>\n",
+    "    ...\n",
+    "    </reasoning>\n",
+    "    <answer>\n",
+    "    ...\n",
+    "    </answer>\n",
+    "    \"\"\"\n",
+    "    return { # Return a conversation format dictionary\n",
+    "        'prompt': [\n",
+    "            {'role': 'system', 'content': SYSTEM_PROMPT},\n",
+    "            {'role': 'user', 'content': row['question']}\n",
+    "        ],\n",
+    "        'question': row['question'],\n",
+    "        'answer': extract_hash_answer(row['answer'])\n",
+    "    }"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Initialize Experiment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Every experiment instance must be uniquely named\n",
+    "experiment = Experiment(experiment_name=\"exp1-math-reasoning-lite\", mode=\"fit\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Define Custom Reward Functions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def correctness_reward_func(prompts, completions, answer, **kwargs) -> list[float]:\n",
+    "\n",
+    "    def extract_xml_answer(text: str) -> str:\n",
+    "        answer = text.split(\"<answer>\")[-1]\n",
+    "        answer = answer.split(\"</answer>\")[0]\n",
+    "        return answer.strip()\n",
+    "\n",
+    "    responses = [completion[0]['content'] for completion in completions]\n",
+    "    q = prompts[0][-1]['content']\n",
+    "    extracted_responses = [extract_xml_answer(r) for r in responses]\n",
+    "    return [2.0 if r == a else 0.0 for r, a in zip(extracted_responses, answer)]\n",
+    "\n",
+    "def int_reward_func(completions, **kwargs) -> list[float]:\n",
+    "    \n",
+    "    def extract_xml_answer(text: str) -> str:\n",
+    "        answer = text.split(\"<answer>\")[-1]\n",
+    "        answer = answer.split(\"</answer>\")[0]\n",
+    "        return answer.strip()\n",
+    "    responses = [completion[0]['content'] for completion in completions]\n",
+    "    extracted_responses = [extract_xml_answer(r) for r in responses]\n",
+    "    return [0.5 if r.isdigit() else 0.0 for r in extracted_responses]\n",
+    "\n",
+    "def strict_format_reward_func(completions, **kwargs) -> list[float]:\n",
+    "    \"\"\"Reward function that checks if the completion has a specific format.\"\"\"\n",
+    "    import re\n",
+    "    pattern = r\"^<reasoning>\\n.*?\\n</reasoning>\\n<answer>\\n.*?\\n</answer>\\n$\"\n",
+    "    responses = [completion[0][\"content\"] for completion in completions]\n",
+    "    matches = [re.match(pattern, r) for r in responses]\n",
+    "    return [0.5 if match else 0.0 for match in matches]\n",
+    "\n",
+    "def soft_format_reward_func(completions, **kwargs) -> list[float]:\n",
+    "    \"\"\"Reward function that checks if the completion has a specific format.\"\"\"\n",
+    "    import re\n",
+    "    pattern = r\"<reasoning>.*?</reasoning>\\s*<answer>.*?</answer>\"\n",
+    "    responses = [completion[0][\"content\"] for completion in completions]\n",
+    "    matches = [re.match(pattern, r) for r in responses]\n",
+    "    return [0.5 if match else 0.0 for match in matches]\n",
+    "\n",
+    "def xmlcount_reward_func(completions, **kwargs) -> list[float]:\n",
+    "    def count_xml(text) -> float:\n",
+    "        count = 0.0\n",
+    "        if text.count(\"<reasoning>\\n\") == 1:\n",
+    "            count += 0.125\n",
+    "        if text.count(\"\\n</reasoning>\\n\") == 1:\n",
+    "            count += 0.125\n",
+    "        if text.count(\"\\n<answer>\\n\") == 1:\n",
+    "            count += 0.125\n",
+    "            count -= len(text.split(\"\\n</answer>\\n\")[-1])*0.001\n",
+    "        if text.count(\"\\n</answer>\") == 1:\n",
+    "            count += 0.125\n",
+    "            count -= (len(text.split(\"\\n</answer>\")[-1]) - 1)*0.001\n",
+    "        return count\n",
+    "    contents = [completion[0][\"content\"] for completion in completions]\n",
+    "    return [count_xml(c) for c in contents]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Define Multi-Config Knobs for Model, LoRA, and GRPO Trainer using RapidFire AI Wrapper APIs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lora_config = RFLoraConfig(\n",
+    "    r=16,\n",
+    "    lora_alpha=16,\n",
+    "    lora_dropout=0.05,\n",
+    "    target_modules=[\"q_proj\", \"k_proj\", \"v_proj\", \"o_proj\", \"gate_proj\", \"down_proj\", \"up_proj\"],\n",
+    "    bias=\"none\"\n",
+    ")\n",
+    "\n",
+    "grpo_config_base = RFGRPOConfig(\n",
+    "    learning_rate=5e-6,\n",
+    "    warmup_ratio=0.1,\n",
+    "    weight_decay=0.1,\n",
+    "    max_grad_norm=0.1,\n",
+    "    adam_beta1=0.9,\n",
+    "    adam_beta2=0.99,\n",
+    "    lr_scheduler_type = \"linear\",\n",
+    "    per_device_train_batch_size=4,\n",
+    "    gradient_accumulation_steps=2,\n",
+    "    num_generations=8,\n",
+    "    optim =\"adamw_8bit\",\n",
+    "    num_train_epochs=1,\n",
+    "    max_prompt_length=256,\n",
+    "    max_completion_length=256,\n",
+    "    logging_steps=2,\n",
+    "    beta=0.0 # No reference model\n",
+    ")\n",
+    "\n",
+    "grpo_config_2 = grpo_config_base.copy()\n",
+    "grpo_config_2.learning_rate = 1e-6\n",
+    "\n",
+    "reward_funcs = [\n",
+    "    correctness_reward_func,\n",
+    "    int_reward_func,\n",
+    "    strict_format_reward_func,\n",
+    "    soft_format_reward_func,\n",
+    "    xmlcount_reward_func,\n",
+    "]\n",
+    "\n",
+    "# List of 2 separate configs\n",
+    "config_set_lite = List([\n",
+    "    RFModelConfig(\n",
+    "        model_name=\"Qwen/Qwen2.5-0.5B-Instruct\",\n",
+    "        peft_config=lora_config,\n",
+    "        training_args=grpo_config_base,\n",
+    "        formatting_func=sample_formatting_function,\n",
+    "        reward_funcs=reward_funcs,\n",
+    "        model_kwargs={\"load_in_4bit\": False, \"device_map\": \"auto\", \"torch_dtype\": \"float16\", \"use_cache\": False},\n",
+    "        tokenizer_kwargs={\"model_max_length\": 512, \"padding_side\": \"left\", \"truncation\": True}\n",
+    "    ),\n",
+    "    RFModelConfig(\n",
+    "        model_name=\"meta-llama/Llama-3.2-1B-Instruct\",\n",
+    "        peft_config=lora_config,\n",
+    "        training_args=grpo_config_2,\n",
+    "        formatting_func=sample_formatting_function,\n",
+    "        reward_funcs=reward_funcs,\n",
+    "        model_kwargs={\"load_in_4bit\": False, \"device_map\": \"auto\", \"torch_dtype\": \"float16\", \"use_cache\": False},\n",
+    "        tokenizer_kwargs={\"model_max_length\": 512, \"padding_side\": \"left\", \"truncation\": True}\n",
+    "    ),\n",
+    "])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Define Model Creation Function"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def sample_create_model(model_config):\n",
+    "   \"\"\"Function to create model object for any given config; must return tuple of (model, tokenizer)\"\"\"\n",
+    "   from transformers import AutoModelForCausalLM, AutoTokenizer\n",
+    "   \n",
+    "   model_name = model_config[\"model_name\"]\n",
+    "   model_kwargs = model_config[\"model_kwargs\"]\n",
+    "   tokenizer_kwargs = model_config[\"tokenizer_kwargs\"]\n",
+    "   return (\n",
+    "      AutoModelForCausalLM.from_pretrained(model_name, **model_kwargs),\n",
+    "      AutoTokenizer.from_pretrained(model_name, **tokenizer_kwargs)\n",
+    "   )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Generate Config Group"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Simple grid search across all sets of config knob values = 3 combinations in total\n",
+    "config_group = RFGridSearch(\n",
+    "    configs=config_set_lite,\n",
+    "    trainer_type=\"GRPO\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Run Multi-Config Training"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Launch training of all configs in the config_group with swap granularity of 6 chunks\n",
+    "experiment.run_fit(config_group, sample_create_model, train_dataset, eval_dataset, num_chunks=4, seed=42)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### End Current Experiment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "experiment.end()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div align=\"center\">\n",
+    "<a href=\"https://rapidfire.ai/\"><img src=\"https://raw.githubusercontent.com/RapidFireAI/rapidfireai/main/doc/images/RapidFire - Blue bug -white text.svg\" width=\"115\"></a>\n",
+    "<a href=\"https://discord.gg/6vSTtncKNN\"><img src=\"https://raw.githubusercontent.com/RapidFireAI/rapidfireai/main/doc/images/discord-button.svg\" width=\"145\"></a>\n",
+    "<a href=\"https://oss-docs.rapidfire.ai/\"><img src=\"https://raw.githubusercontent.com/RapidFireAI/rapidfireai/main/doc/images/documentation-button.svg\" width=\"125\"></a>\n",
+    "<br/>\n",
+    "Thanks for trying RapidFire AI! \u2b50 <i>Star us on <a href=\"https://github.com/RapidFireAI/rapidfireai\">GitHub</a></i> \u2b50\n",
+    "</div>\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tutorial_notebooks/rf-tutorial-sft-chatqa-lite.ipynb
+++ b/tutorial_notebooks/rf-tutorial-sft-chatqa-lite.ipynb
@@ -1,0 +1,357 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div align=\"center\">\n",
+    "<a href=\"https://rapidfire.ai/\"><img src=\"https://raw.githubusercontent.com/RapidFireAI/rapidfireai/main/docs/images/RapidFire - Blue bug -white text.svg\" width=\"115\"></a>\n",
+    "<a href=\"https://discord.gg/6vSTtncKNN\"><img src=\"https://raw.githubusercontent.com/RapidFireAI/rapidfireai/main/docs/images/discord-button.svg\" width=\"145\"></a>\n",
+    "<a href=\"https://oss-docs.rapidfire.ai/\"><img src=\"https://raw.githubusercontent.com/RapidFireAI/rapidfireai/main/docs/images/documentation-button.svg\" width=\"125\"></a>\n",
+    "<br/>\n",
+    "Join Discord if you need help + \u2b50 <i>Star us on <a href=\"https://github.com/RapidFireAI/rapidfireai\">GitHub</a></i> \u2b50\n",
+    "<br/>\n",
+    "To install RapidFire AI on your own machine, see the <a href=\"https://oss-docs.rapidfire.ai/en/latest/walkthrough.html\">Install and Get Started</a> guide in our docs.\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### RapidFire AI Tutorial Use Case: SFT for Customer Support Q&A Chatbot"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from rapidfireai import Experiment\n",
+    "from rapidfireai.fit.automl import List, RFGridSearch, RFModelConfig, RFLoraConfig, RFSFTConfig"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Load Dataset and Specify Train and Eval Partitions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datasets import load_dataset\n",
+    "\n",
+    "dataset=load_dataset(\"bitext/Bitext-customer-support-llm-chatbot-training-dataset\")\n",
+    "\n",
+    "# Select a subset of the dataset for demo purposes\n",
+    "train_dataset=dataset[\"train\"].select(range(128))\n",
+    "eval_dataset=dataset[\"train\"].select(range(100,124))\n",
+    "train_dataset=train_dataset.shuffle(seed=42)\n",
+    "eval_dataset=eval_dataset.shuffle(seed=42)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Define Data Processing Function"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def sample_formatting_function(row):\n",
+    "    \"\"\"Function to preprocess each example from dataset\"\"\"\n",
+    "    # Special tokens for formatting\n",
+    "    SYSTEM_PROMPT = \"You are a helpful and friendly customer support assistant. Please answer the user's query to the best of your ability.\"\n",
+    "    return {\n",
+    "        \"prompt\": [\n",
+    "            {\"role\": \"system\", \"content\": SYSTEM_PROMPT},\n",
+    "            {\"role\": \"user\", \"content\": row[\"instruction\"]},\n",
+    "            \n",
+    "        ],\n",
+    "        \"completion\": [\n",
+    "            {\"role\": \"assistant\", \"content\": row[\"response\"]}\n",
+    "        ]\n",
+    "    }"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Initialize Experiment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Every experiment instance must be uniquely named\n",
+    "experiment = Experiment(experiment_name=\"exp1-chatqa-lite\", mode=\"fit\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Define Custom Eval Metrics Function"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def sample_compute_metrics(eval_preds):  \n",
+    "    \"\"\"Optional function to compute eval metrics based on predictions and labels\"\"\"\n",
+    "    predictions, labels = eval_preds\n",
+    "\n",
+    "    # Standard text-based eval metrics: Rouge and BLEU\n",
+    "    import evaluate\n",
+    "    rouge = evaluate.load(\"rouge\")\n",
+    "    bleu = evaluate.load(\"bleu\")\n",
+    "\n",
+    "    rouge_output = rouge.compute(predictions=predictions, references=labels, use_stemmer=True)\n",
+    "    rouge_l = rouge_output[\"rougeL\"]\n",
+    "    bleu_output = bleu.compute(predictions=predictions, references=labels)\n",
+    "    bleu_score = bleu_output[\"bleu\"]\n",
+    "\n",
+    "    return {\n",
+    "        \"rougeL\": round(rouge_l, 4),\n",
+    "        \"bleu\": round(bleu_score, 4),\n",
+    "    }"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Define Multi-Config Knobs for Model, LoRA, and SFT Trainer using RapidFire AI Wrapper APIs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 2 LoRA PEFT configs lite with different adapter capacities\n",
+    "peft_configs_lite = List([\n",
+    "    RFLoraConfig(\n",
+    "        r=8,\n",
+    "        lora_alpha=16,\n",
+    "        lora_dropout=0.1,\n",
+    "        target_modules=[\"q_proj\", \"v_proj\"],  # Standard transformer naming\n",
+    "        bias=\"none\"\n",
+    "    ),\n",
+    "    RFLoraConfig(\n",
+    "        r=32,\n",
+    "        lora_alpha=64,\n",
+    "        lora_dropout=0.1,\n",
+    "        target_modules=[\"q_proj\", \"k_proj\", \"v_proj\", \"o_proj\"],  # Standard naming\n",
+    "        bias=\"none\"\n",
+    "    )\n",
+    "])\n",
+    "\n",
+    "# 2 base models x 2 peft configs = 4 combinations in total\n",
+    "config_set_lite = List([\n",
+    "    RFModelConfig(\n",
+    "        model_name=\"TinyLlama/TinyLlama-1.1B-Chat-v1.0\",  # 1.1B model\n",
+    "        peft_config=peft_configs_lite,\n",
+    "        training_args=RFSFTConfig(\n",
+    "            learning_rate=1e-3,  # Higher LR for very small model\n",
+    "            lr_scheduler_type=\"linear\",\n",
+    "            per_device_train_batch_size=4,\n",
+    "            per_device_eval_batch_size=4,\n",
+    "            max_steps=128,\n",
+    "            gradient_accumulation_steps=1,   # No accumulation needed\n",
+    "            logging_steps=2,\n",
+    "            eval_strategy=\"steps\",\n",
+    "            eval_steps=4,\n",
+    "            fp16=True,\n",
+    "        ),\n",
+    "        model_type=\"causal_lm\",\n",
+    "        model_kwargs={\"device_map\": \"auto\", \"torch_dtype\": \"auto\", \"use_cache\": False},\n",
+    "        formatting_func=sample_formatting_function,\n",
+    "        compute_metrics=sample_compute_metrics,\n",
+    "        generation_config={\n",
+    "            \"max_new_tokens\": 256,\n",
+    "            \"temperature\": 0.8,  # Higher temp for tiny model\n",
+    "            \"top_p\": 0.9,\n",
+    "            \"top_k\": 30,         # Reduced top_k\n",
+    "            \"repetition_penalty\": 1.05,\n",
+    "        }\n",
+    "    ),\n",
+    "    RFModelConfig(\n",
+    "        model_name=\"TinyLlama/TinyLlama-1.1B-Chat-v1.0\",  # 1.1B model\n",
+    "        peft_config=peft_configs_lite,\n",
+    "        training_args=RFSFTConfig(\n",
+    "            learning_rate=1e-4,  # Higher LR for very small model\n",
+    "            lr_scheduler_type=\"linear\",\n",
+    "            per_device_train_batch_size=4,  # Even larger batch size\n",
+    "            per_device_eval_batch_size=4,\n",
+    "            max_steps=128,\n",
+    "            gradient_accumulation_steps=1,   # No accumulation needed\n",
+    "            logging_steps=2,\n",
+    "            eval_strategy=\"steps\",\n",
+    "            eval_steps=4,\n",
+    "            fp16=True,\n",
+    "        ),\n",
+    "        model_type=\"causal_lm\",\n",
+    "        model_kwargs={\"device_map\": \"auto\", \"torch_dtype\": \"auto\", \"use_cache\": False},\n",
+    "        formatting_func=sample_formatting_function,\n",
+    "        compute_metrics=sample_compute_metrics,\n",
+    "        generation_config={\n",
+    "            \"max_new_tokens\": 256,\n",
+    "            \"temperature\": 0.8,  # Higher temp for tiny model\n",
+    "            \"top_p\": 0.9,\n",
+    "            \"top_k\": 30,         # Reduced top_k\n",
+    "            \"repetition_penalty\": 1.05,\n",
+    "        }\n",
+    "    )\n",
+    "])\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Define Model Creation Function for All Model Types Across Configs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "def sample_create_model(model_config): \n",
+    "     \"\"\"Function to create model object for any given config; must return tuple of (model, tokenizer)\"\"\"\n",
+    "     from transformers import AutoModelForCausalLM, AutoTokenizer, AutoModelForSeq2SeqLM, AutoModelForMaskedLM\n",
+    "\n",
+    "     model_name = model_config[\"model_name\"]\n",
+    "     model_type = model_config[\"model_type\"]\n",
+    "     model_kwargs = model_config[\"model_kwargs\"]\n",
+    " \n",
+    "     if model_type == \"causal_lm\":\n",
+    "          model = AutoModelForCausalLM.from_pretrained(model_name, **model_kwargs)\n",
+    "     elif model_type == \"seq2seq_lm\":\n",
+    "          model = AutoModelForSeq2SeqLM.from_pretrained(model_name, **model_kwargs)\n",
+    "     elif model_type == \"masked_lm\":\n",
+    "          model = AutoModelForMaskedLM.from_pretrained(model_name, **model_kwargs)\n",
+    "     elif model_type == \"custom\":\n",
+    "          # Handle custom model loading logic, e.g., loading your own checkpoints\n",
+    "          # model = ... \n",
+    "          pass\n",
+    "     else:\n",
+    "          # Default to causal LM\n",
+    "          model = AutoModelForCausalLM.from_pretrained(model_name, **model_kwargs)\n",
+    "      \n",
+    "     tokenizer = AutoTokenizer.from_pretrained(model_name)\n",
+    "      \n",
+    "     return (model,tokenizer)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Generate Config Group"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Simple grid search across all sets of config knob values = 4 combinations in total\n",
+    "config_group = RFGridSearch(\n",
+    "    configs=config_set_lite,\n",
+    "    trainer_type=\"SFT\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Run Multi-Config Training"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Launch training of all configs in the config_group with swap granularity of 4 chunks\n",
+    "experiment.run_fit(config_group, sample_create_model, train_dataset, eval_dataset, num_chunks=4, seed=42)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### End Current Experiment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "experiment.end()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div align=\"center\">\n",
+    "<a href=\"https://rapidfire.ai/\"><img src=\"https://raw.githubusercontent.com/RapidFireAI/rapidfireai/main/docs/images/RapidFire - Blue bug -white text.svg\" width=\"115\"></a>\n",
+    "<a href=\"https://discord.gg/6vSTtncKNN\"><img src=\"https://raw.githubusercontent.com/RapidFireAI/rapidfireai/main/docs/images/discord-button.svg\" width=\"145\"></a>\n",
+    "<a href=\"https://oss-docs.rapidfire.ai/\"><img src=\"https://raw.githubusercontent.com/RapidFireAI/rapidfireai/main/docs/images/documentation-button.svg\" width=\"125\"></a>\n",
+    "<br/>\n",
+    "Thanks for trying RapidFire AI! \u2b50 <i>Star us on <a href=\"https://github.com/RapidFireAI/rapidfireai\">GitHub</a></i> \u2b50\n",
+    "</div>"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "lite",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
## Problem
The HuggingFace TRL documentation page links to three tutorial notebooks that were moved during a recent repository reorganization, causing broken links:
- \	utorial_notebooks/rf-tutorial-sft-chatqa-lite.ipynb\
- \	utorial_notebooks/rf-tutorial-dpo-alignment-lite.ipynb\
- \	utorial_notebooks/rf-tutorial-grpo-mathreasoning-lite.ipynb\

These notebooks are now located in subdirectories (\ine-tuning/\ and \post-training/\), but external documentation still references the old paths.

## Solution
Copy the three notebooks back to the root of \	utorial_notebooks/\ to restore backward compatibility with the HuggingFace documentation links. This maintains both the new organized folder structure AND the old flat structure for external references.

## Changes
- Added \	utorial_notebooks/rf-tutorial-sft-chatqa-lite.ipynb\ (copy from \ine-tuning/\)
- Added \	utorial_notebooks/rf-tutorial-dpo-alignment-lite.ipynb\ (copy from \post-training/\)
- Added \	utorial_notebooks/rf-tutorial-grpo-mathreasoning-lite.ipynb\ (copy from \post-training/\)

## Impact
- Fixes broken links on https://huggingface.co/docs/trl/en/rapidfire_integration
- No breaking changes - notebooks remain in their organized subdirectories
- Minimal repository size increase (duplicate files for backward compatibility)