### PR TITLE
Improve FiQA RAG Colab notebook explanations

### DIFF
--- a/tutorial_notebooks/rag-contexteng/rf-colab-rag-fiqa-tutorial.ipynb
+++ b/tutorial_notebooks/rag-contexteng/rf-colab-rag-fiqa-tutorial.ipynb
@@ -33,9 +33,41 @@
    "source": [
     "# Optimizing RAG Pipelines with RapidFire AI\n",
     "\n",
-    "Retrieval-Augmented Generation (RAG) has become the standard for building knowledgeable AI assistants. However, building a production-ready RAG pipeline involves making dozens of choices: What chunk size should I use? Which embedding model? Should I rerank? Which LLM works best for my budget?\n",
+    "Retrieval-Augmented Generation (RAG) is a practical way to make an AI assistant **answer using your documents**:\n",
     "\n",
-    "In this tutorial, we'll use [RapidFireAI](https://github.com/RapidFireAI/rapidfireai) to systematically optimize a RAG pipeline for a Financial Opinion Q&A chatbot. Using the [FiQA dataset](https://huggingface.co/datasets/explodinggradients/fiqa), we'll explore how to tune both the retrieval (LangChain) and generation (vLLM) components."
+    "- **Retrieve**: find the most relevant passages for a question.\n",
+    "- **Generate**: give those passages to a language model so it can answer *grounded in evidence*.\n",
+    "\n",
+    "In this beginner-friendly Colab, we’ll build and evaluate a RAG pipeline for a **financial opinion Q&A** assistant using the [FiQA dataset](https://huggingface.co/datasets/explodinggradients/fiqa).\n",
+    "\n",
+    "Examples of the kind of questions we’re targeting:\n",
+    "\n",
+    "- “Should I invest in index funds or individual stocks?”\n",
+    "- “What’s a good way to save for retirement in my 30s?”\n",
+    "- “Is it worth refinancing my mortgage right now?”\n",
+    "\n",
+    "## What We’re Building\n",
+    "\n",
+    "A concrete RAG pipeline that looks like this:\n",
+    "\n",
+    "1. **Load a financial corpus** (documents + posts).\n",
+    "2. **Split documents into chunks** (so we can search smaller, more relevant pieces).\n",
+    "3. **Embed the chunks** (turn text into vectors) and store them in a vector index (FAISS).\n",
+    "4. **Retrieve top‑K chunks** for each question using similarity search.\n",
+    "5. *(Optional)* **Rerank** the retrieved chunks with a stronger model to keep only the best evidence.\n",
+    "6. **Build a prompt** that includes the question + retrieved context.\n",
+    "7. **Generate an answer** with a small vLLM model.\n",
+    "8. **Evaluate retrieval quality** (Precision, Recall, NDCG@5, MRR) so we can tell which settings find better evidence.\n",
+    "\n",
+    "## Our Approach\n",
+    "\n",
+    "RAG has a lot of “knobs”, and it’s easy to lose track of what helped. In this notebook we’ll focus on **retrieval quality** by keeping the generator (the vLLM model) fixed and only varying retrieval settings.\n",
+    "\n",
+    "We’ll use [RapidFireAI](https://github.com/RapidFireAI/rapidfireai) to:\n",
+    "\n",
+    "- **Define a small retrieval grid**: 2 chunking strategies × 2 reranking `top_n` values = **4 retrieval configs**.\n",
+    "- **Run all configs the same way** on the same dataset.\n",
+    "- **Compare retrieval metrics side-by-side** as they update (Precision/Recall/NDCG/MRR) to pick the best evidence-finding setup."
    ]
   },
   {
@@ -43,7 +75,12 @@
    "id": "e4c769cc",
    "metadata": {},
    "source": [
-    "### Install and Initialize RapidFire AI"
+    "## Install RapidFire AI Package and Setup\n",
+    "### Option 1: Install Locally (or on a VM)\n",
+    "For the full RapidFire AI experience—advanced experiment management, UI, and production features—we recommend installing the package on a machine you control (for example, a VM or your local machine) rather than Google Colab. See our [Install and Get Started](https://oss-docs.rapidfire.ai/en/latest/walkthrough.html) guide.\n",
+    "\n",
+    "### Option 2: Install in Google Colab\n",
+    "For simplicity, you can run this notebook on Google Colab. This notebook is configured to run end-to-end on Colab with no local installation required."
    ]
   },
   {
@@ -57,7 +94,7 @@
     "    import rapidfireai\n",
     "    print(\"✅ rapidfireai already installed\")\n",
     "except ImportError:\n",
-    "    !pip install rapidfireai  # Takes 1 min\n",
+    "    %pip install rapidfireai  # Takes 1 min\n",
     "    !rapidfireai init --evals # Takes 1 min"
    ]
   },
@@ -66,7 +103,9 @@
    "id": "3b703a70",
    "metadata": {},
    "source": [
-    "### Import RapidFire Components"
+    "### Import RapidFire Components\n",
+    "\n",
+    "Import RapidFire’s core classes for defining the RAG pipeline and running a small retrieval grid search (plus a Colab-friendly protobuf setting)."
    ]
   },
   {
@@ -84,7 +123,7 @@
     "import re, json\n",
     "from typing import List as listtype, Dict, Any\n",
     "\n",
-    "# NB: If you get \"AttributeError: 'MessageFactory' object has no attribute 'GetPrototype'\" from Colab, just rerun this cell"
+    "# If you get \"AttributeError: 'MessageFactory' object has no attribute 'GetPrototype'\" from Colab, just rerun this cell"
    ]
   },
   {
@@ -92,9 +131,11 @@
    "id": "9e16327b",
    "metadata": {},
    "source": [
-    "### Load Dataset, Rename Columns, and Downsample Data\n",
+    "### Loading the Data\n",
     "\n",
-    "**Note:** sample_fraction set extremely low to avoid Colab disconnect, recommend setting it higher as noted"
+    "We load the FiQA **queries** and **relevance labels (qrels)**, then downsample to keep this Colab run fast.\n",
+    "Next we filter the corpus to only documents relevant to the sampled queries and write a smaller `corpus_sampled.jsonl`.\n",
+    "Finally, we update `qrels` to match the sampled subset so evaluation stays consistent."
    ]
   },
   {
@@ -121,7 +162,7 @@
     ")\n",
     "\n",
     "# Downsample queries and corpus JOINTLY\n",
-    "sample_fraction = 0.001  # NB: makes demo faster but degrades metrics; set to 1.0 for full evals\n",
+    "sample_fraction = 0.001  # low sample_fraction makes demo faster but degrades metrics; set to 1.0 for full evals if running on a local machine.\n",
     "rseed = 1\n",
     "random.seed(rseed)\n",
     "\n",
@@ -164,28 +205,18 @@
   },
   {
    "cell_type": "markdown",
-   "id": "28399289",
-   "metadata": {},
-   "source": [
-    "### Create Experiment"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "70816920",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "experiment = Experiment(experiment_name=\"exp1-fiqa-rag-colab\", mode=\"evals\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "a73a21ee",
    "metadata": {},
    "source": [
-    "### Define Partial Multi-Config Knobs for LangChain part of RAG Pipeline using RapidFire AI Wrapper APIs"
+    "### Defining the RAG Search Space\n",
+    "This is where RapidFireAI shines. Instead of hardcoding a single RAG configuration, we define a search space using RFLangChainRagSpec.\n",
+    "\n",
+    "We will test:\n",
+    "\n",
+    "* **2 Chunking Strategies**: Different chunk sizes (256 vs 128).\n",
+    "* **2 Reranking Strategies**: Different `top_n` values (2 vs 5).\n",
+    "\n",
+    "This gives us 4 combinations to evaluate for the retrieval part."
    ]
   },
   {
@@ -256,7 +287,10 @@
    "id": "dd6fb0a8",
    "metadata": {},
    "source": [
-    "### Define Data Processing and Postprocessing Functions"
+    "### Define Data Processing and Postprocessing Functions\n",
+    "\n",
+    "We retrieve context for each question and turn it into LLM-ready prompts.\n",
+    "Then we attach the “ground truth” relevant documents from FiQA (`qrels`) so we can score retrieval quality later."
    ]
   },
   {
@@ -317,7 +351,10 @@
    "id": "39eb16c3",
    "metadata": {},
    "source": [
-    "### Define Custom Eval Metrics Functions"
+    "### Define Custom Eval Metrics Functions\n",
+    "\n",
+    "The following helper methods compute standard retrieval metrics (Precision, Recall, F1, NDCG@5, MRR) from the retrieved vs. ground-truth document IDs.\n",
+    "We compute metrics per batch and then combine them across batches so each config gets one consistent score."
    ]
   },
   {
@@ -423,7 +460,8 @@
    "source": [
     "### Define Partial Multi-Config Knobs for vLLM Generator part of RAG Pipeline using RapidFire AI Wrapper APIs\n",
     "\n",
-    "This tutorial showcases Qwen2.5-0.5B-Instruct (0.5B parameters), which is perfect for Colab's memory constraints"
+    "We pick a lightweight vLLM model and sampling settings that fit in Colab GPU memory.\n",
+    "Then we bundle the generator + our preprocessing/metrics functions into `config_set`, which RapidFire will run across the 4 retrieval configs."
    ]
   },
   {
@@ -477,7 +515,10 @@
    "id": "3a7dd280",
    "metadata": {},
    "source": [
-    "### Create Config Group"
+    "### Create Config Group\n",
+    "\n",
+    "We create an `RFGridSearch` over `config_set`, producing **4 retrieval configs** (2 chunkers × 2 rerankers) to run and compare.\n",
+    "\n"
    ]
   },
   {
@@ -496,7 +537,9 @@
    "id": "6e8a0e92",
    "metadata": {},
    "source": [
-    "### Display Ray Dashboard (Optional)"
+    "### Display Ray Dashboard (Optional)\n",
+    "\n",
+    "Ray is the system RapidFire uses under the hood to run work in parallel; this cell simply embeds Ray’s dashboard below so we can monitor what’s running."
    ]
   },
   {
@@ -509,6 +552,27 @@
     "# Display the Ray dashboard in the Colab notebook\n",
     "from google.colab import output\n",
     "output.serve_kernel_port_as_iframe(8855)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "77b4b0d6",
+   "metadata": {},
+   "source": [
+    "### Create Experiment\n",
+    "\n",
+    "An `Experiment` is RapidFire’s top-level container for this notebook run: it groups configs/runs, saves artifacts, and tracks metrics under a unique name.\n",
+    "We set `mode=\"evals\"` because we’re running evaluation (not training). See the docs: https://oss-docs.rapidfire.ai/en/latest/experiment.html#api-experiment\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8850ee71",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "experiment = Experiment(experiment_name=\"exp1-fiqa-rag-colab\", mode=\"evals\")"
    ]
   },
   {
@@ -642,6 +706,20 @@
     "            print(line.rstrip())\n",
     "else:\n",
     "    print(f\"❌ Log file not found: {log_file}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "20e420d4",
+   "metadata": {},
+   "source": [
+    "### Conclusion\n",
+    "\n",
+    "We built a simple Financial Q&A RAG pipeline and compared **4 retrieval configurations** (chunking × reranking) using standard retrieval metrics.\n",
+    "\n",
+    "Optional ideas to explore later:\n",
+    "- Increase `sample_fraction` (or run locally) for more reliable results.\n",
+    "- Try additional retrieval knobs (e.g., embedding model, `k`, chunk overlap) and re-run the same evaluation loop.\n"
    ]
   }
  ],


### PR DESCRIPTION
### Summary
This PR improves the beginner-friendliness and narrative flow of the FiQA RAG Colab notebook.

### What changed
- Rewrote the opening intro to explain the concrete RAG pipeline being optimized (retrieve → optional rerank → generate → evaluate).
- Clarified that the grid search is **retrieval-only**: 2 chunking strategies × 2 reranking `top_n` values = **4 configs** (generator stays fixed).
- Added short explanations above key code cells (imports, data loading + downsampling, RAG search space, preprocessing/postprocessing, metrics, config group, Ray dashboard, experiment creation).
- Moved the experiment creation cells to sit immediately before the `run_evals` section for a more linear read.
- Added a short **Conclusion** section with optional future ideas.

### Files
- `tutorial_notebooks/rag-contexteng/rf-colab-rag-fiqa-tutorial.ipynb`
