### PR TITLE
Fix metric logger options

### DIFF
--- a/rapidfireai/experiment.py
+++ b/rapidfireai/experiment.py
@@ -203,9 +203,8 @@ class Experiment:
             metric_experiment_id = self.metric_loggers.create_experiment(self.experiment_name)
             self.db.db.execute(
                 "UPDATE experiments SET metric_experiment_id = ? WHERE experiment_id = ?",
-                (metric_experiment_id, self.experiment_id),
+                (metric_experiment_id, self.experiment_id), commit=True
             )
-            self.db.db.conn.commit()
             self.logger.info(f"Initialized MetricLogger experiment: {metric_experiment_id}")
         except Exception as e:
             self.logger.warning(f"Failed to initialize MetricLogger: {e}. MetricLogger logging will be disabled.")

--- a/tutorial_notebooks/rag-contexteng/rf-colab-rag-fiqa-tutorial.ipynb
+++ b/tutorial_notebooks/rag-contexteng/rf-colab-rag-fiqa-tutorial.ipynb
@@ -536,6 +536,27 @@
   },
   {
    "cell_type": "markdown",
+   "id": "77b4b0d6",
+   "metadata": {},
+   "source": [
+    "### Create Experiment\n",
+    "\n",
+    "An `Experiment` is RapidFire’s top-level container for this notebook run: it groups configs/runs, saves artifacts, and tracks metrics under a unique name.\n",
+    "We set `mode=\"evals\"` because we’re running evaluation (not training). See the docs: https://oss-docs.rapidfire.ai/en/latest/experiment.html#api-experiment\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ae4b5729",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "experiment = Experiment(experiment_name=\"exp1-fiqa-rag-colab\", mode=\"evals\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "6e8a0e92",
    "metadata": {},
    "source": [
@@ -554,27 +575,6 @@
     "# Display the Ray dashboard in the Colab notebook\n",
     "from google.colab import output\n",
     "output.serve_kernel_port_as_iframe(8855)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "77b4b0d6",
-   "metadata": {},
-   "source": [
-    "### Create Experiment\n",
-    "\n",
-    "An `Experiment` is RapidFire’s top-level container for this notebook run: it groups configs/runs, saves artifacts, and tracks metrics under a unique name.\n",
-    "We set `mode=\"evals\"` because we’re running evaluation (not training). See the docs: https://oss-docs.rapidfire.ai/en/latest/experiment.html#api-experiment\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "8850ee71",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "experiment = Experiment(experiment_name=\"exp1-fiqa-rag-colab\", mode=\"evals\")"
    ]
   },
   {


### PR DESCRIPTION
## Changes
- Fix issue with evals tracking db missing commit.
- Moved Ray dashboard to after Experiment initialization, as that is when Ray is starte

## Testing
- [ ] Tested on Colab



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - **Evals DB/metrics:** In `Experiment._init_evals_mode`, update `experiments.metric_experiment_id` using `db.execute(..., commit=True)` and remove manual connection commit.
> - **Colab tutorial:** Reorder cells to **create the `Experiment` before displaying the Ray dashboard**, with corresponding markdown/code cell ID swaps and text updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 929e31aec205b07c6bacbc59bff0bba191fca3e4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->