### PR TITLE
fix: use experiment.experiment_name for trackio.show() in tutorial notebooks

### DIFF
--- a/tutorial_notebooks/fine-tuning/trackio/rf-colab-tutorial-sft-trackio.ipynb
+++ b/tutorial_notebooks/fine-tuning/trackio/rf-colab-tutorial-sft-trackio.ipynb
@@ -432,7 +432,7 @@
         "id": "wJfXimPpAxJl"
       },
       "source": [
-        "## Display Trackio Dashboard\n",
+        "## View Metrics with Trackio Dashboard\n",
         "\n",
         "**Run this cell to display the Trackio dashboard. Metrics will appear in real-time as training progresses.**"
       ]
@@ -557,7 +557,7 @@
         "id": "wuiwNvldAxJm"
       },
       "source": [
-        "## View Trackio Dashboard\n",
+        "## View Metrics with Trackio Dashboard\n",
         "\n",
         "After your experiment ends, you can still view the Trackio dashboard:"
       ]

--- a/tutorial_notebooks/rag-contexteng/trackio/rf-colab-tutorial-rag-fiqa-trackio.ipynb
+++ b/tutorial_notebooks/rag-contexteng/trackio/rf-colab-tutorial-rag-fiqa-trackio.ipynb
@@ -604,7 +604,7 @@
         "### Create Experiment\n",
         "\n",
         "An `Experiment` is RapidFire’s top-level container for this notebook run: it groups configs/runs, saves artifacts, and tracks metrics under a unique name.\n",
-        "We set `mode=\"evals\"` because we’re running evaluation (not training). See the docs: https://oss-docs.rapidfire.ai/en/latest/experiment.html#api-experiment\n"
+        "We set `mode=\"evals\"` because we’re running evaluation. See the docs: https://oss-docs.rapidfire.ai/en/latest/experiment.html#api-experiment\n"
       ],
       "id": "77b4b0d6"
     },
@@ -743,7 +743,14 @@
         "id": "suDZAZmHGSWg"
       },
       "source": [
-        "### Display Trackio Dashboard"
+        "### View Metrics with Trackio Dashboard\n",
+        "\n",
+        "**Run this cell to display the Trackio dashboard. Metrics will appear in real-time as evaluation progresses.**\n",
+        "\n",
+        "The dashboard allows you to:\n",
+        "- View real-time metrics estimates and confidence intervals\n",
+        "- Compare metrics across different configurations\n",
+        "- Analyze impact of various knobs on performance"
       ],
       "id": "suDZAZmHGSWg"
     },

--- a/tutorial_notebooks/rag-contexteng/trackio/rf-tutorial-rag-fiqa-trackio.ipynb
+++ b/tutorial_notebooks/rag-contexteng/trackio/rf-tutorial-rag-fiqa-trackio.ipynb
@@ -2,7 +2,6 @@
   "cells": [
     {
       "cell_type": "markdown",
-      "id": "e06d0c6d",
       "metadata": {},
       "source": [
         "<div align=\"center\">\n",
@@ -14,11 +13,11 @@
         "<br/>\n",
         "To install RapidFire AI on your own machine, see the <a href=\"https://oss-docs.rapidfire.ai/en/latest/walkthrough.html\">Install and Get Started</a> guide in our docs.\n",
         "</div>"
-      ]
+      ],
+      "id": "e06d0c6d"
     },
     {
       "cell_type": "markdown",
-      "id": "644fc36b",
       "metadata": {},
       "source": [
         "# RapidFire AI Tutorial: Optimizing RAG Pipelines with Trackio Experiment Tracking \n",
@@ -60,11 +59,11 @@
         "- **Compare retrieval metrics side-by-side** as they update (Precision/Recall/NDCG/MRR) to pick the best evidence-finding setup.\n",
         "\n",
         "We use **Trackio** for experiment tracking and visualization."
-      ]
+      ],
+      "id": "644fc36b"
     },
     {
       "cell_type": "markdown",
-      "id": "d5184c3b",
       "metadata": {},
       "source": [
         "### Configure Trackio and Import RapidFire Components\n",
@@ -72,14 +71,12 @@
         "First, we enable Trackio as the experiment tracking backend and disable MLflow and TensorBoard. These environment variables must be set **before** importing RapidFire components.\n",
         "\n",
         "Then we import RapidFire's core classes for defining the RAG pipeline and running a grid search."
-      ]
+      ],
+      "id": "d5184c3b"
     },
     {
       "cell_type": "code",
-      "execution_count": null,
-      "id": "3f8598e1",
       "metadata": {},
-      "outputs": [],
       "source": [
         "import os\n",
         "\n",
@@ -94,24 +91,24 @@
         "from rapidfireai.automl import List, RFLangChainRagSpec, RFvLLMModelConfig, RFPromptManager, RFGridSearch\n",
         "import re, json\n",
         "from typing import List as listtype, Dict, Any"
-      ]
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "3f8598e1"
     },
     {
       "cell_type": "markdown",
-      "id": "9e16327b",
       "metadata": {},
       "source": [
         "### Loading the Data\n",
         "\n",
         "We load the FiQA **queries** and **relevance labels (qrels)**. The qrels file contains ground truth information about which documents are relevant to which queries, which we'll use to evaluate retrieval quality."
-      ]
+      ],
+      "id": "9e16327b"
     },
     {
       "cell_type": "code",
-      "execution_count": null,
-      "id": "ee571098",
       "metadata": {},
-      "outputs": [],
       "source": [
         "from datasets import load_dataset\n",
         "import pandas as pd\n",
@@ -126,31 +123,33 @@
         "qrels = qrels.rename(\n",
         "    columns={\"query-id\": \"query_id\", \"corpus-id\": \"corpus_id\", \"score\": \"relevance\"}\n",
         ")"
-      ]
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "ee571098"
     },
     {
       "cell_type": "markdown",
-      "id": "28399289",
       "metadata": {},
       "source": [
         "### Create Experiment\n",
         "\n",
-        "An `Experiment` is RapidFire's top-level container for this notebook run: it groups configs/runs, saves artifacts, and tracks metrics under a unique name. We set `mode=\"evals\"` because we're running evaluation (not training). See the [Experiment API docs](https://oss-docs.rapidfire.ai/en/latest/experiment.html#api-experiment) for more details."
-      ]
+        "An `Experiment` is RapidFire's top-level container for this notebook run: it groups configs/runs, saves artifacts, and tracks metrics under a unique name. We set `mode=\"evals\"` because we're running evaluation. See the [Experiment API docs](https://oss-docs.rapidfire.ai/en/latest/experiment.html#api-experiment) for more details."
+      ],
+      "id": "28399289"
     },
     {
       "cell_type": "code",
-      "execution_count": null,
-      "id": "70816920",
       "metadata": {},
-      "outputs": [],
       "source": [
         "experiment = Experiment(experiment_name=\"exp1-fiqa-rag-trackio\", mode=\"evals\")"
-      ]
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "70816920"
     },
     {
       "cell_type": "markdown",
-      "id": "a73a21ee",
       "metadata": {},
       "source": [
         "### Defining the RAG Search Space\n",
@@ -163,14 +162,12 @@
         "* **2 Reranking Strategies**: Different `top_n` values (2 vs 5).\n",
         "\n",
         "This gives us 4 retrieval combinations to evaluate. Combined with 2 generator models, we get **8 total configurations**."
-      ]
+      ],
+      "id": "a73a21ee"
     },
     {
       "cell_type": "code",
-      "execution_count": null,
-      "id": "02b73586",
       "metadata": {},
-      "outputs": [],
       "source": [
         "from langchain_community.document_loaders import DirectoryLoader, JSONLoader\n",
         "from langchain_text_splitters import RecursiveCharacterTextSplitter\n",
@@ -226,11 +223,13 @@
         "    },\n",
         "    enable_gpu_search=True,  # GPU-based exact search instead of ANN index\n",
         ")"
-      ]
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "02b73586"
     },
     {
       "cell_type": "markdown",
-      "id": "dd6fb0a8",
       "metadata": {},
       "source": [
         "### Define Data Processing and Postprocessing Functions\n",
@@ -241,14 +240,12 @@
         "3. Serializes context into prompts for the generator\n",
         "\n",
         "The postprocessing function attaches \"ground truth\" relevant documents from FiQA (`qrels`) so we can score retrieval quality later."
-      ]
+      ],
+      "id": "dd6fb0a8"
     },
     {
       "cell_type": "code",
-      "execution_count": null,
-      "id": "ecc17276",
       "metadata": {},
-      "outputs": [],
       "source": [
         "def sample_preprocess_fn(\n",
         "    batch: Dict[str, listtype], rag: RFLangChainRagSpec, prompt_manager: RFPromptManager\n",
@@ -294,11 +291,13 @@
         "        for query_id in batch[\"query_id\"]\n",
         "    ]\n",
         "    return batch"
-      ]
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "ecc17276"
     },
     {
       "cell_type": "markdown",
-      "id": "39eb16c3",
       "metadata": {},
       "source": [
         "### Define Custom Eval Metrics Functions\n",
@@ -312,14 +311,12 @@
         "- **MRR**: Mean Reciprocal Rank (how early does the first relevant doc appear?).\n",
         "\n",
         "We compute metrics per batch and then combine them across batches so each config gets one consistent score."
-      ]
+      ],
+      "id": "39eb16c3"
     },
     {
       "cell_type": "code",
-      "execution_count": null,
-      "id": "22773d53",
       "metadata": {},
-      "outputs": [],
       "source": [
         "import math\n",
         "\n",
@@ -408,11 +405,13 @@
         "            for metric in algebraic_metrics\n",
         "        },\n",
         "    }"
-      ]
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "22773d53"
     },
     {
       "cell_type": "markdown",
-      "id": "c57887bc",
       "metadata": {},
       "source": [
         "### Define vLLM Generator Configurations\n",
@@ -425,14 +424,12 @@
         "Each generator config will be combined with the 4 retrieval configs (2 chunking × 2 reranking), giving us 8 total configurations to evaluate.\n",
         "\n",
         "We bundle the generators with our preprocessing/metrics functions into `config_set`, which RapidFire will run across all configurations."
-      ]
+      ],
+      "id": "c57887bc"
     },
     {
       "cell_type": "code",
-      "execution_count": null,
-      "id": "8f5d0824",
       "metadata": {},
-      "outputs": [],
       "source": [
         "# 2 vLLM generator configs with different sizes of generator models\n",
         "\n",
@@ -491,32 +488,34 @@
         "        \"use_fpc\": True,\n",
         "    },\n",
         "}"
-      ]
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "8f5d0824"
     },
     {
       "cell_type": "markdown",
-      "id": "3a7dd280",
       "metadata": {},
       "source": [
         "### Create Config Group\n",
         "\n",
         "We create an `RFGridSearch` over `config_set`, producing **8 total configs** (2 generators × 2 chunkers × 2 rerankers) to run and compare."
-      ]
+      ],
+      "id": "3a7dd280"
     },
     {
       "cell_type": "code",
-      "execution_count": null,
-      "id": "67f26d9d",
       "metadata": {},
-      "outputs": [],
       "source": [
         "# Simple grid search across all sets of config knob values = 8 combinations in total\n",
         "config_group = RFGridSearch(config_set)"
-      ]
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "67f26d9d"
     },
     {
       "cell_type": "markdown",
-      "id": "fa186134",
       "metadata": {},
       "source": [
         "### Run Multi-Config Evals\n",
@@ -533,14 +532,12 @@
         "- 🗑️ **Delete**: Remove a run from this experiment\n",
         "- 📋 **Clone**: Create a new run by editing the config dictionary of a parent run\n",
         "- 🔄 **Refresh**: Update run status and metrics"
-      ]
+      ],
+      "id": "fa186134"
     },
     {
       "cell_type": "code",
-      "execution_count": null,
-      "id": "8e07274a",
       "metadata": {},
-      "outputs": [],
       "source": [
         "# Launch evals of all RAG configs in the config_group with swap granularity of 4 chunks\n",
         "# NB: If your machine has only 1 GPU, set num_actors=1\n",
@@ -551,14 +548,16 @@
         "    num_shards=4,\n",
         "    seed=42,\n",
         ")"
-      ]
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "8e07274a"
     },
     {
       "cell_type": "markdown",
-      "id": "5489898b",
       "metadata": {},
       "source": [
-        "### View Trackio Dashboard\n",
+        "### View Metrics with Trackio Dashboard\n",
         "\n",
         "To visualize your experiment metrics in the Trackio dashboard, open a terminal and run:\n",
         "\n",
@@ -567,25 +566,23 @@
         "```\n",
         "\n",
         "This will launch the Trackio dashboard in your browser where you can:\n",
-        "- View real-time training curves\n",
+        "- View real-time metrics estimates and confidence intervals\n",
         "- Compare metrics across different configurations\n",
-        "- Analyze hyperparameter impacts on performance"
-      ]
+        "- Analyze impact of various knobs on performance"
+      ],
+      "id": "5489898b"
     },
     {
       "cell_type": "markdown",
-      "id": "656ce33b",
       "metadata": {},
       "source": [
         "### View Results"
-      ]
+      ],
+      "id": "656ce33b"
     },
     {
       "cell_type": "code",
-      "execution_count": null,
-      "id": "127e7b4a",
       "metadata": {},
-      "outputs": [],
       "source": [
         "# Convert results dict to DataFrame\n",
         "results_df = pd.DataFrame([\n",
@@ -594,40 +591,40 @@
         "])\n",
         "\n",
         "results_df"
-      ]
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "127e7b4a"
     },
     {
       "cell_type": "markdown",
-      "id": "9135d951",
       "metadata": {},
       "source": [
         "### End Experiment"
-      ]
+      ],
+      "id": "9135d951"
     },
     {
       "cell_type": "code",
-      "execution_count": null,
-      "id": "94ab038d",
       "metadata": {},
-      "outputs": [],
       "source": [
         "experiment.end()"
-      ]
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "94ab038d"
     },
     {
       "cell_type": "markdown",
-      "id": "09265e66",
       "metadata": {},
       "source": [
         "### View RapidFire AI Log Files"
-      ]
+      ],
+      "id": "09265e66"
     },
     {
       "cell_type": "code",
-      "execution_count": null,
-      "id": "05379a93",
       "metadata": {},
-      "outputs": [],
       "source": [
         "# Get the experiment-specific log file\n",
         "log_file = experiment.get_log_file_path()\n",
@@ -645,11 +642,13 @@
         "            print(line.rstrip())\n",
         "else:\n",
         "    print(f\"❌ Log file not found: {log_file}\")"
-      ]
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "05379a93"
     },
     {
       "cell_type": "markdown",
-      "id": "b3d5816f",
       "metadata": {},
       "source": [
         "### Conclusion\n",
@@ -666,7 +665,8 @@
         "- Try additional retrieval knobs (e.g., different embedding models, varying `k`, chunk overlap settings)\n",
         "- Add generation quality metrics alongside retrieval metrics\n",
         "- Scale to larger datasets or more generator model comparisons"
-      ]
+      ],
+      "id": "b3d5816f"
     }
   ],
   "metadata": {


### PR DESCRIPTION
## Summary
- Fixed undefined variable bug in trackio tutorial notebooks
- Changed from using a separate variable (`experiment_name` or `my_experiment`) to using `experiment.experiment_name` directly
- This approach is safer because it avoids potential issues with variable name reuse across multiple experiment runs

## Files Changed
- `tutorial_notebooks/rag-contexteng/trackio/rf-colab-tutorial-rag-fiqa-trackio.ipynb`
- `tutorial_notebooks/fine-tuning/trackio/rf-colab-tutorial-sft-trackio.ipynb`

## Test plan
- [ ] Run the RAG notebook cells in order and verify no NameError occurs at the trackio.show() cell
- [ ] Run the SFT notebook cells in order and verify no NameError occurs at the trackio.show() cell

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only touches tutorial notebooks and mostly corrects a variable reference plus minor metadata/text edits; no production code paths affected.
> 
> **Overview**
> Fixes Trackio tutorial notebooks to reliably open the correct dashboard by calling `trackio.show(project=experiment.experiment_name)` instead of referencing separate/undefined project-name variables.
> 
> Also includes minor notebook cleanups/metadata normalization (cell `id` placement, `execution_count`/`outputs` ordering) and small wording tweaks around the Trackio dashboard sections.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 711504d505956625d5625a98522a3f64afb5479c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->