### PR TITLE
trackio legend display changes and import error in dispatcher

### DIFF
--- a/rapidfireai/evals/scheduling/controller.py
+++ b/rapidfireai/evals/scheduling/controller.py
@@ -607,8 +607,7 @@ class Controller:
             metric_run_id = None
             if self.metric_manager:
                 try:
-                    pipeline_name = pipeline_config.get("pipeline_name", f"Pipeline {pipeline_id}")
-                    metric_run_id = self.metric_manager.create_run(f"{pipeline_name}_{pipeline_id}")
+                    metric_run_id = self.metric_manager.create_run(str(pipeline_id))
                     db.set_pipeline_metric_run_id(pipeline_id, metric_run_id)
 
                     pipeline = pipeline_config.get("pipeline")

--- a/rapidfireai/evals/scheduling/interactive_control.py
+++ b/rapidfireai/evals/scheduling/interactive_control.py
@@ -457,8 +457,7 @@ class InteractiveControlHandler:
         # Create metric run for the cloned pipeline (mirrors _register_pipelines and fit mode's _create_models)
         if self.metric_manager:
             try:
-                pipeline_name = edited_json.get("pipeline_name", f"Pipeline {new_pipeline_id}")
-                metric_run_id = self.metric_manager.create_run(f"{pipeline_name}_{new_pipeline_id}")
+                metric_run_id = self.metric_manager.create_run(str(new_pipeline_id))
                 db.set_pipeline_metric_run_id(new_pipeline_id, metric_run_id)
 
                 # Log parent-run param (consistent with fit mode)

--- a/rapidfireai/evals/utils/logger.py
+++ b/rapidfireai/evals/utils/logger.py
@@ -6,6 +6,15 @@ from rapidfireai.utils.constants import RF_LOG_FILENAME, RF_LOG_PATH, RF_EXPERIM
 from rapidfireai.utils.os_utils import mkdir_p
 
 
+class SafeLoggerAdapter(logging.LoggerAdapter):
+    """Custom LoggerAdapter that prefixes messages with experiment and logger name."""
+    def process(self, msg, kwargs):
+        # Prefix message with experiment and logger name
+        experiment = self.extra.get("experiment_name", "unknown")
+        log_name = self.extra.get("logger_name", "unknown")
+        return f"[{experiment}:{log_name}] {msg}", kwargs
+
+
 class RFLogger:
     _file_handler = None
     _experiment_name = None
@@ -99,14 +108,6 @@ class RFLogger:
     def get_logger(self, logger_name: str = "unknown"):
         logger = logging.getLogger(logger_name)
         logger.setLevel(self.level)
-
-        # Custom LoggerAdapter that prefixes messages instead of using format fields
-        class SafeLoggerAdapter(logging.LoggerAdapter):
-            def process(self, msg, kwargs):
-                # Prefix message with experiment and logger name
-                experiment = self.extra.get("experiment_name", "unknown")
-                log_name = self.extra.get("logger_name", "unknown")
-                return f"[{experiment}:{log_name}] {msg}", kwargs
 
         return SafeLoggerAdapter(
             logger,


### PR DESCRIPTION
## Problem  (#160 )

Incorrect legend labels: Metrics were displaying as "Pipeline 1_1", "Pipeline 2_2", "Pipeline 3_3" instead of the expected run IDs: "1", "2", "3"
Import error: Dispatcher was importing SafeLoggerAdapter which is not defined in logger.py's context properly.

## Changes

evals/controller.py: Updated metric logger call to use pipeline_id as run_id
evals/interactive_control.py: Updated metric logger call to use pipeline_id as run_id

## Testing

✅ Verified fix using RAG FIQA Notebook
✅ Legends now display clean run IDs (1, 2, 3...) as expected

## ScreenShot
<img width="1366" height="812" alt="Screenshot 2026-02-02 at 12 17 44 PM" src="https://github.com/user-attachments/assets/9d6e4819-c767-49d2-adf8-4faa7db59a7b" />


