### PR TITLE
Change Interactive control log string

### DIFF
--- a/rapidfireai/evals/dispatcher/dispatcher.py
+++ b/rapidfireai/evals/dispatcher/dispatcher.py
@@ -958,7 +958,7 @@ class Dispatcher:
             ic_logs = []
             with open(log_file_path, encoding="utf-8") as f:
                 for line in f:
-                    if f"| {experiment_name} | interactive-control |" in line:
+                    if f"[{experiment_name}:InteractiveControl]" in line:
                         ic_logs.append(line.strip())
 
             return jsonify(ic_logs), 200


### PR DESCRIPTION
## Changes
- IC Logs for evals looking for same string as training

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> A small string-match change in log filtering that only affects which lines are returned from the IC logs endpoint.
> 
> **Overview**
> Updates the evals dispatcher `get_ic_logs` endpoint to filter interactive-control log lines using the bracketed tag format `[{experiment_name}:InteractiveControl]` instead of the older pipe-delimited `| {experiment_name} | interactive-control |` string, aligning evals IC log retrieval with training log output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d3800cf6c49080c9b7eacc1b7775af434ead32cd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->