### PR TITLE
Add community notebooks for RAG and SFT

### DIFF
--- a/community_notebooks/rag_fiqa_context_optimization.ipynb
+++ b/community_notebooks/rag_fiqa_context_optimization.ipynb
@@ -1149,41 +1149,7 @@
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
-     "height": 1000,
-     "resources": {
-      "http://localhost:8851/dispatcher/get-pipeline-config-json/3": {
-       "data": "eyJjb250ZXh0X2lkIjozLCJwaXBlbGluZV9jb25maWdfanNvbiI6eyJiYXRjaF9zaXplIjozLCJjbGllbnRfY29uZmlnIjp7ImFwaV9rZXkiOiJzay1wcm9qLWNnNmdWYnBibW05ZlpVTnFpOHRYSERpdnliRTVvMXNwR2VQYVRHcmtLalkzcUtwUEUxOTNTYnpLYkx1Q2JSNHhTaHhQT1lUOU1LVDNCbGJrRkowU19HZW1VdFdWWnh6bUxydEJiM1R5TmFCYkJwTUI1SDdfNmZtTk54MDR2TVRjWFRBYl9Jenl5Z043b1VTU3BtQVdoUG5TS0FJQSIsIm1heF9yZXRyaWVzIjoyfSwibWF4X2NvbXBsZXRpb25fdG9rZW5zIjoxMjgsIm1vZGVsX2NvbmZpZyI6eyJtYXhfY29tcGxldGlvbl90b2tlbnMiOjEyOCwibW9kZWwiOiJncHQtNG8tbWluaSIsInRlbXBlcmF0dXJlIjowLjh9LCJvbmxpbmVfc3RyYXRlZ3lfa3dhcmdzIjp7ImNvbmZpZGVuY2VfbGV2ZWwiOjAuOTUsInN0cmF0ZWd5X25hbWUiOiJub3JtYWwiLCJ1c2VfZnBjIjp0cnVlfSwicGlwZWxpbmVfdHlwZSI6Im9wZW5haSIsInJhZ19jb25maWciOnsiY2h1bmtfb3ZlcmxhcCI6MzIsImNodW5rX3NpemUiOjI1NiwiayI6MTIsInNlYXJjaF90eXBlIjoic2ltaWxhcml0eSIsInRvcF9uIjozfSwicnBtX2xpbWl0Ijo1MDAsInRwbV9saW1pdCI6MjAwMDAwfX0K",
-       "headers": [
-        [
-         "content-length",
-         "627"
-        ],
-        [
-         "content-type",
-         "application/json"
-        ]
-       ],
-       "ok": true,
-       "status": 200,
-       "status_text": ""
-      },
-      "http://localhost:8851/dispatcher/list-all-pipeline-ids": {
-       "data": "W3sicGlwZWxpbmVfaWQiOjMsInNoYXJkc19jb21wbGV0ZWQiOjQsInN0YXR1cyI6ImNvbXBsZXRlZCIsInRvdGFsX3NhbXBsZXNfcHJvY2Vzc2VkIjo4fSx7InBpcGVsaW5lX2lkIjoyLCJzaGFyZHNfY29tcGxldGVkIjo0LCJzdGF0dXMiOiJjb21wbGV0ZWQiLCJ0b3RhbF9zYW1wbGVzX3Byb2Nlc3NlZCI6OH0seyJwaXBlbGluZV9pZCI6MSwic2hhcmRzX2NvbXBsZXRlZCI6NCwic3RhdHVzIjoiY29tcGxldGVkIiwidG90YWxfc2FtcGxlc19wcm9jZXNzZWQiOjh9XQo=",
-       "headers": [
-        [
-         "content-length",
-         "266"
-        ],
-        [
-         "content-type",
-         "application/json"
-        ]
-       ],
-       "ok": true,
-       "status": 200,
-       "status_text": ""
-      }
-     }
+     "height": 1000
     },
     "id": "HLxnMVK7Vuno",
     "outputId": "b9d67c7d-5862-47cd-a025-666aef7df3e5"


### PR DESCRIPTION
## Changes
- Add community notebooks for RAG and SFT competition submissions.
- Update notebooks for API changes and fixes (switch to rapidfireai.automl, cleaned/updated versions).
- Add community_notebooks/README.md with acknowledgments and support note.

Test plan: not run (docs/notebooks only).

## Testing
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have tested this change manually
- [ ] I have tested this change in the following environments:
  - [ ] Local development
  - [ ] Docker environment
  - [ ] Other: _______________

## Screenshots (if applicable)
Add screenshots to help explain your changes.

## Checklist
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Performance Impact
If this PR affects performance, describe the impact and any optimizations made.

## Related Issues
Fixes #(issue number)
Closes #(issue number)
Related to #(issue number)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs/notebook-only additions with no changes to library/runtime code; main risk is increased repo size and potential for notebooks to drift with dependency/API changes.
> 
> **Overview**
> Adds a new `community_notebooks/` section with contributor acknowledgements and two end-to-end Colab notebooks demonstrating RapidFire AI RAG evaluation workflows.
> 
> The new notebooks cover (1) FiQA financial QA context-length optimization by comparing multiple retrieval/reranking configurations under a 3000-token budget using `run_evals`, and (2) NFCorpus biomedical QA retrieval-first grid search including dataset download/ID normalization, multi-config RAG setup, metric computation, and result visualization.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ad2444db4eb0a9ac90ec03030a100305aa1fec3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->