### PR TITLE
Accept documented Experiment constructor aliases

### DIFF
--- a/rapidfireai/experiment.py
+++ b/rapidfireai/experiment.py
@@ -28,9 +28,6 @@ class _StopExecution(Exception):
     """Raised to halt cell execution silently after an error is displayed in Jupyter."""
 
 
-_UNSET = object()
-
-
 def display_pretty_error(msg: str) -> None:
     try:
         from IPython import get_ipython
@@ -60,7 +57,7 @@ class Experiment:
         self,
         experiment_name: str,
         mode: str = "fit",
-        experiment_path: str | object = _UNSET,
+        experiment_path: str | None = None,
         num_cpus: int = None,
         num_gpus: int = None,
         experiments_path: str | None = None,
@@ -78,13 +75,10 @@ class Experiment:
             TypeError: If experiment_path and experiments_path are both provided with different values
             ValueError: If mode is not "fit", "eval", or "evals"
         """
-        if experiment_path is _UNSET:
-            resolved_experiment_path = RF_EXPERIMENT_PATH
-        else:
-            resolved_experiment_path = experiment_path
+        resolved_experiment_path = RF_EXPERIMENT_PATH if experiment_path is None else experiment_path
 
         if experiments_path is not None:
-            if experiment_path is not _UNSET and resolved_experiment_path != experiments_path:
+            if experiment_path is not None and experiment_path != experiments_path:
                 raise TypeError(
                     "experiment_path and experiments_path refer to the same setting and must match when both are provided"
                 )

--- a/rapidfireai/experiment.py
+++ b/rapidfireai/experiment.py
@@ -27,6 +27,10 @@ from rapidfireai.utils.constants import (
 class _StopExecution(Exception):
     """Raised to halt cell execution silently after an error is displayed in Jupyter."""
 
+
+_UNSET = object()
+
+
 def display_pretty_error(msg: str) -> None:
     try:
         from IPython import get_ipython
@@ -56,28 +60,45 @@ class Experiment:
         self,
         experiment_name: str,
         mode: str = "fit",
-        experiment_path: str = RF_EXPERIMENT_PATH,
+        experiment_path: str | object = _UNSET,
         num_cpus: int = None,
         num_gpus: int = None,
+        experiments_path: str | None = None,
     ) -> None:
         """
         Initialize an experiment.
 
         Args:
             experiment_name: Name of the experiment
-            mode: Either "fit" or "evals"
+            mode: Either "fit" or "evals". "eval" is accepted as an alias for "evals".
             experiment_path: Path to store experiment artifacts (default: $RF_HOME/rapidfire_experiments)
+            experiments_path: Alias for experiment_path accepted for compatibility with published docs
 
         Raises:
-            ValueError: If mode is not "fit" or "evals"
+            TypeError: If experiment_path and experiments_path are both provided with different values
+            ValueError: If mode is not "fit", "eval", or "evals"
         """
-        # Validate mode
-        if mode not in ["fit", "evals"]:
-            raise ValueError(f"Invalid mode: {mode}. Must be 'fit' or 'evals'")
+        if experiment_path is _UNSET:
+            resolved_experiment_path = RF_EXPERIMENT_PATH
+        else:
+            resolved_experiment_path = experiment_path
 
-        self.mode = mode
+        if experiments_path is not None:
+            if experiment_path is not _UNSET and resolved_experiment_path != experiments_path:
+                raise TypeError(
+                    "experiment_path and experiments_path refer to the same setting and must match when both are provided"
+                )
+            resolved_experiment_path = experiments_path
+
+        normalized_mode = "evals" if mode == "eval" else mode
+
+        # Validate mode
+        if normalized_mode not in ["fit", "evals"]:
+            raise ValueError(f"Invalid mode: {mode}. Must be 'fit', 'eval', or 'evals'")
+
+        self.mode = normalized_mode
         self.experiment_name = experiment_name
-        self.experiment_path = experiment_path
+        self.experiment_path = resolved_experiment_path
         self.experiment_id = None
 
         if num_cpus is not None and num_cpus <= 0:
@@ -85,9 +106,9 @@ class Experiment:
         
         if num_gpus is not None and num_gpus < 0:
             display_pretty_error(f"Invalid number of GPUs: {num_gpus}. Must be non-negative")
-        
+
         # Initialize based on mode
-        if mode == "fit":
+        if self.mode == "fit":
             self._init_fit_mode()
         else:
             self._ray_resource_config = self._auto_detect_resources(num_cpus=num_cpus, num_gpus=num_gpus)

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -1,0 +1,57 @@
+import pytest
+
+from rapidfireai.experiment import Experiment
+
+
+@pytest.fixture(autouse=True)
+def patch_experiment_initializers(monkeypatch):
+    monkeypatch.setattr(Experiment, "_init_fit_mode", lambda self: None, raising=False)
+    monkeypatch.setattr(Experiment, "_init_evals_mode", lambda self: None, raising=False)
+    monkeypatch.setattr(
+        Experiment,
+        "_auto_detect_resources",
+        lambda self, num_cpus=None, num_gpus=None: {
+            "cpus_for_ray": 1,
+            "gpus_for_ray": 0,
+            "num_actors": 1,
+            "gpus_per_actor": 0.0,
+            "cpus_per_actor": 1.0,
+        },
+        raising=False,
+    )
+
+
+def test_eval_alias_normalizes_to_evals():
+    experiment = Experiment(experiment_name="demo", mode="eval")
+
+    assert experiment.mode == "evals"
+
+
+def test_experiments_path_alias_sets_experiment_path():
+    experiment = Experiment(experiment_name="demo", experiments_path="/tmp/custom-experiments")
+
+    assert experiment.experiment_path == "/tmp/custom-experiments"
+
+
+def test_same_path_aliases_are_allowed():
+    experiment = Experiment(
+        experiment_name="demo",
+        experiment_path="/tmp/custom-experiments",
+        experiments_path="/tmp/custom-experiments",
+    )
+
+    assert experiment.experiment_path == "/tmp/custom-experiments"
+
+
+def test_conflicting_path_aliases_raise_error():
+    with pytest.raises(TypeError, match="experiment_path and experiments_path"):
+        Experiment(
+            experiment_name="demo",
+            experiment_path="/tmp/fit-experiments",
+            experiments_path="/tmp/eval-experiments",
+        )
+
+
+def test_invalid_mode_error_lists_supported_values():
+    with pytest.raises(ValueError, match="Must be 'fit', 'eval', or 'evals'"):
+        Experiment(experiment_name="demo", mode="train")


### PR DESCRIPTION
## Summary
This fixes the `Experiment` constructor mismatch reported in #224 by accepting the documented aliases while keeping the existing internal API stable.

## What changed
- accept `mode="eval"` as an alias for the existing canonical `"evals"` mode
- accept `experiments_path=` as an alias for `experiment_path=`
- raise a clear `TypeError` if both path arguments are provided with different values
- update constructor docstrings and validation messaging to describe the supported inputs
- add focused constructor tests for alias normalization, conflict handling, and invalid mode errors

## Root cause
The published docs referenced `eval` and `experiments_path`, but the constructor only accepted `evals` and `experiment_path`.

## Validation
- `python -m pytest tests/test_experiment.py`

Fixes #224

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to `Experiment.__init__` argument normalization/validation plus new unit tests, with no changes to training/evals execution paths beyond selecting the same canonical mode/path values.
> 
> **Overview**
> Aligns `Experiment` constructor behavior with documented inputs by accepting `mode="eval"` as an alias for `"evals"` and adding `experiments_path` as an alias of `experiment_path`.
> 
> Adds stricter validation: conflicting `experiment_path`/`experiments_path` now raises a clear `TypeError`, mode validation/error messaging now lists all supported values, and new pytest coverage verifies normalization and error cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ffd8c9f5d1a0b97b1708f910319010bdcb9921e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->