### PR TITLE
Jupyter flush output

### DIFF
--- a/rapidfireai/cli.py
+++ b/rapidfireai/cli.py
@@ -474,6 +474,7 @@ def run_jupyter():
         print("\n\nAfter forwarding the ports above, access the Jupyter notebook at:")
         print(f"http://localhost:{app.port}/tree?token={app.token}")
 
+        print("\n\nStarting Jupyter server...")
         sys.stdout.flush()
         sys.stderr.flush()
         

--- a/rapidfireai/cli.py
+++ b/rapidfireai/cli.py
@@ -445,6 +445,12 @@ def run_jupyter():
     stderr_capture = io.StringIO()
 
     try:
+        sys.stdout.reconfigure(line_buffering=True)
+        sys.stderr.reconfigure(line_buffering=True)
+    except AttributeError:
+        pass
+
+    try:
         with redirect_stdout(stdout_capture), redirect_stderr(stderr_capture):
             app.initialize(argv=['--ServerApp.custom_display_url='])
         
@@ -467,6 +473,9 @@ def run_jupyter():
         print(f"   jupyter notebook --no-browser --port={app.port} --ServerApp.allow_origin='*' --ServerApp.default_url='/tree' --ServerApp.token=''")
         print("\n\nAfter forwarding the ports above, access the Jupyter notebook at:")
         print(f"http://localhost:{app.port}/tree?token={app.token}")
+
+        sys.stdout.flush()
+        sys.stderr.flush()
         
         # Don't redirect anything during start - let prompts through
         app.start()


### PR DESCRIPTION
## Changes
- Flushes output of `rapidfireai jupyter` before starting Jupyter

## Changelog Content
### Fixes
- Addresses issue #220 


## Screenshots (if applicable)
<img width="826" height="200" alt="image" src="https://github.com/user-attachments/assets/ccd33544-8e07-438e-aade-868699fc7de1" />

## Related Issues
Fixes #220 
Closes #220 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change limited to CLI stdout/stderr buffering/flush behavior around `rapidfireai jupyter` startup; could only affect console output timing/ordering.
> 
> **Overview**
> Improves `rapidfireai jupyter` startup UX by ensuring printed port-forwarding instructions appear immediately before the Jupyter server begins.
> 
> This sets `stdout`/`stderr` to line-buffered when supported and explicitly `flush()`es both streams right before `app.start()`, with a new "Starting Jupyter server..." message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12d0a22125f08cfec1cbeda75b17a396f862c0e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->