### PR TITLE
bugfix: tolerate corrupt pipeline_config dill blob in get_all_pipelines

### DIFF
--- a/rapidfireai/evals/db/rf_db.py
+++ b/rapidfireai/evals/db/rf_db.py
@@ -760,7 +760,12 @@ class RFDatabase:
 
             for row in result:
                 # Decode the pipeline config from the database (use pipeline_config column)
-                decoded_config = decode_db_payload(row[3]) if row[3] else None
+                decoded_config = None
+                if row[3]:
+                    try:
+                        decoded_config = decode_db_payload(row[3])
+                    except Exception:
+                        decoded_config = None
                 # Parse JSON config for display/analytics
                 json_config = json.loads(row[4]) if row[4] else None
                 flattened_config = json.loads(row[5]) if row[5] else {}

--- a/tests/test_rf_db_get_all_pipelines.py
+++ b/tests/test_rf_db_get_all_pipelines.py
@@ -1,0 +1,59 @@
+"""Regression test: get_all_pipelines must not 500 when a single row has a
+corrupt dill blob in pipeline_config."""
+
+import json
+from unittest.mock import Mock
+
+from rapidfireai.evals.db.rf_db import RFDatabase
+
+
+def _make_db(rows):
+    db_iface = Mock()
+    db_iface.execute.return_value = rows
+    rf = RFDatabase.__new__(RFDatabase)
+    rf.db = db_iface
+    return rf
+
+
+def _row(
+    pipeline_id,
+    pipeline_config_blob,
+    json_config=None,
+    flattened_config=None,
+    status="Ongoing",
+):
+    return (
+        pipeline_id,
+        "ctx-1",
+        "sft",
+        pipeline_config_blob,
+        json.dumps(json_config or {}),
+        json.dumps(flattened_config or {}),
+        status,
+        0,
+        0,
+        0,
+        None,
+        None,
+        "2026-04-21",
+    )
+
+
+def test_get_all_pipelines_tolerates_corrupt_dill_blob():
+    rows = [
+        _row(1, None),
+        _row(2, "!!not-valid-base64-or-dill!!"),
+        _row(3, None),
+    ]
+    rf = _make_db(rows)
+
+    pipelines = rf.get_all_pipelines()
+
+    assert len(pipelines) == 3
+    assert [p["pipeline_id"] for p in pipelines] == [1, 2, 3]
+    assert all(p["pipeline_config"] is None for p in pipelines)
+
+
+def test_get_all_pipelines_returns_empty_list_when_no_rows():
+    rf = _make_db([])
+    assert rf.get_all_pipelines() == []


### PR DESCRIPTION
## Summary

Fixes the HTTP 500 on \`/dispatcher/get-all-runs\` (and \`/dispatcher/get-all-pipelines\`) that Chethan hit during mid-run sanity testing of RF Converge. It surfaced in Converge as issues #1 (Metrics not visible to agent) and #2 (Auto-Pilot took no actions), because every fetch of run state 500'd.

Root cause: \`get_all_pipelines\` unconditionally \`decode_db_payload(row[3])\` (dill.loads on a base64 blob) for every row. When any single row's \`pipeline_config\` column is corrupt / stale, \`dill.UnpicklingError\` propagates out of the loop and the whole listing fails with 500. Observed failure on main:

\`\`\`
dill.UnpicklingError: NEWOBJ class argument must be a type, not NoneType
\`\`\`

Fix: wrap the decode in try/except. A bad row yields \`pipeline_config=None\` for just that row, matching the existing behavior for rows where \`row[3]\` is NULL. Callers that truly need the decoded object already use \`get_pipeline(pipeline_id)\`, which is unchanged.

Internal callers of \`db.get_all_pipelines()\` (only the two route handlers in \`evals/dispatcher/dispatcher.py\`) either jsonify the result (where a dill object can't be serialized anyway) or pass it through \`_transform_pipeline_to_run\` which only reads \`pipeline_config_json\` / \`flattened_config\`. No route reads the decoded \`pipeline_config\`.

Companion PR on the Converge side: RapidFireAI/rapidfireai-pro#46. That one is defensive only (surfaces "Dispatcher unavailable" when this endpoint 500s); once this lands the agent goes back to actually reading metrics and taking actions.

## Test plan

- [x] \`pytest tests/test_rf_db_get_all_pipelines.py\` — 2 passing (regression + empty-list)
- [x] Verified the regression test **fails on \`main\`** with \`UnpicklingError: invalid load key\` (same failure family as the reported bug)
- [ ] Full live repro against a real corrupted DB row — Chethan's environment; not reproduced locally in this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized error-handling change in a read-path plus a unit test; main risk is silently masking unexpected decode issues for `pipeline_config` in list responses.
> 
> **Overview**
> Prevents `get_all_pipelines` from failing the entire listing when a single row contains an invalid/corrupt `pipeline_config` dill blob by catching decode errors and returning `pipeline_config=None` for that row.
> 
> Adds regression coverage to ensure corrupt blobs don’t raise and that an empty DB result returns `[]`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00191d51a5efb1fc4abc366dc553f14128d27a16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->