### PR TITLE
Decouple RFOpenAIAPIModelConfig and RFGeminiAPIModelConfig from vLLM availability

### DIFF
--- a/rapidfireai/automl/model_config.py
+++ b/rapidfireai/automl/model_config.py
@@ -293,7 +293,8 @@ else:
     RFPromptManager = None
 
 
-# Conditionally define evals model config classes only if dependencies are available
+# RFvLLMModelConfig requires vLLM (a self-hosted local inference engine).
+# vLLM is unavailable on macOS Apple Silicon and other CPU-only platforms.
 if (
     _VLLM_AVAILABLE
     and _EVALS_MODULES_AVAILABLE
@@ -356,6 +357,17 @@ if (
             # Use vars() to get only the attributes actually set on the object
             # This works across different vLLM versions
             return dict(vars(self.sampling_params))
+
+else:
+    RFvLLMModelConfig = None
+
+
+# RFOpenAIAPIModelConfig and RFGeminiAPIModelConfig only require the evals modules
+# (LangChainRagSpec, PromptManager, OpenAIInferenceEngine / GoogleGeminiInferenceEngine).
+# They do NOT require vLLM because OpenAI and Gemini are remote APIs and never run a
+# local inference engine. Gating them behind _VLLM_AVAILABLE makes them unusable on
+# CPU-only platforms (macOS Apple Silicon, Datahub CPU pods) for no reason.
+if _EVALS_MODULES_AVAILABLE and InferenceEngine is not None:
 
     class RFOpenAIAPIModelConfig(ModelConfig):
         """OpenAI API model configuration for evals mode."""
@@ -514,7 +526,6 @@ if (
             return {k: v for k, v in self.model_config.items() if k not in _non_sampling_keys}
 
 else:
-    # Define placeholder classes if dependencies are not available
-    RFvLLMModelConfig = None
+    # Evals modules unavailable: API configs cannot be defined.
     RFOpenAIAPIModelConfig = None
     RFGeminiAPIModelConfig = None

--- a/rapidfireai/evals/scheduling/interactive_control.py
+++ b/rapidfireai/evals/scheduling/interactive_control.py
@@ -370,11 +370,14 @@ class InteractiveControlHandler:
         pipeline_type = edited_json.get("pipeline_type")
         if not pipeline_type:
             # If not specified in JSON, infer from parent
-            if isinstance(parent_model_config, RFvLLMModelConfig):
+            # Each isinstance() guarded because the class is None on platforms
+            # where the corresponding inference engine isn't available
+            # (e.g. RFvLLMModelConfig is None on macOS Apple Silicon).
+            if RFvLLMModelConfig is not None and isinstance(parent_model_config, RFvLLMModelConfig):
                 pipeline_type = "vllm"
-            elif isinstance(parent_model_config, RFOpenAIAPIModelConfig):
+            elif RFOpenAIAPIModelConfig is not None and isinstance(parent_model_config, RFOpenAIAPIModelConfig):
                 pipeline_type = "openai"
-            elif isinstance(parent_model_config, RFGeminiAPIModelConfig):
+            elif RFGeminiAPIModelConfig is not None and isinstance(parent_model_config, RFGeminiAPIModelConfig):
                 pipeline_type = "gemini"
             else:
                 raise ValueError("Cannot determine pipeline type from parent")
@@ -576,7 +579,11 @@ class InteractiveControlHandler:
         pipeline = pipeline_config["pipeline"]
 
         # Extract model name
-        if isinstance(model_config, (RFOpenAIAPIModelConfig, RFGeminiAPIModelConfig, RFvLLMModelConfig)):
+        # Filter out classes that are None on this platform (vLLM unavailable on macOS, etc.)
+        _model_cfg_classes = tuple(
+            c for c in (RFOpenAIAPIModelConfig, RFGeminiAPIModelConfig, RFvLLMModelConfig) if c is not None
+        )
+        if _model_cfg_classes and isinstance(model_config, _model_cfg_classes):
             model_name = model_config.model_config.get("model", "Unknown")
         elif hasattr(pipeline, "model_config") and pipeline.model_config is not None:
             model_name = pipeline.model_config.get("model", "Unknown")

--- a/rapidfireai/evals/utils/serialize.py
+++ b/rapidfireai/evals/utils/serialize.py
@@ -93,7 +93,9 @@ def extract_pipeline_config_json(pipeline_config: dict[str, Any]) -> dict[str, A
 
             return rag_config if rag_config else None
 
-        if isinstance(pipeline, RFvLLMModelConfig):
+        # RFvLLMModelConfig is None on platforms where vLLM cannot be installed
+        # (e.g., macOS Apple Silicon). Guard isinstance() to avoid TypeError.
+        if RFvLLMModelConfig is not None and isinstance(pipeline, RFvLLMModelConfig):
             json_config["pipeline_type"] = "vllm"
 
             # Extract model_config (dict)


### PR DESCRIPTION
## Summary

- Currently `RFvLLMModelConfig`, `RFOpenAIAPIModelConfig`, and `RFGeminiAPIModelConfig` are all defined inside one big `if _VLLM_AVAILABLE and _EVALS_MODULES_AVAILABLE` guard in `rapidfireai/automl/model_config.py`.
- On platforms where vLLM cannot be installed (macOS Apple Silicon, CPU-only Datahub pods, etc.), all three classes silently become `None` — even though the OpenAI and Gemini classes only call remote HTTP APIs and have no actual vLLM dependency.
- This makes the OpenAI/Gemini API config classes unusable on platforms where they should work fine, contradicting the project's own documentation (e.g., the RAG walkthrough's "for RAG/context engineering with only closed model APIs, GPUs are not needed" guidance).

## Fix

Split the guard into two:

- `RFvLLMModelConfig` stays gated on `_VLLM_AVAILABLE` (it genuinely uses `SamplingParams`).
- `RFOpenAIAPIModelConfig` and `RFGeminiAPIModelConfig` are now gated only on `_EVALS_MODULES_AVAILABLE` (i.e., the evals modules + the inference engines), since they have no vLLM dependency.

## Verification

Tested on macOS Apple Silicon with `vllm` not installed:

| | Before | After |
|---|---|---|
| `RFvLLMModelConfig` | `None` | `None` (unchanged — correct) |
| `RFOpenAIAPIModelConfig` | `None` | `<class>` ✓ |
| `RFGeminiAPIModelConfig` | `None` | `<class>` ✓ |

Instantiation also succeeds for the API configs:

```python
RFOpenAIAPIModelConfig(
    client_config={"api_key": "test", "base_url": "https://example.com"},
    model_config={"model": "test-model", "max_completion_tokens": 256},
    rpm_limit=120, tpm_limit=1_000_000,
)
# now works on Apple Silicon (where it returned None before)
```

## Context

Encountered this while running RapidFire AI for a CSE234 (UCSD) course project on a CPU-only environment. Happy to add a regression test if useful.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: mainly refactors dependency gating and adds `None`-safe `isinstance` checks to avoid platform-specific `TypeError`s; behavior change is enabling OpenAI/Gemini eval configs on CPU-only platforms.
> 
> **Overview**
> Enables `RFOpenAIAPIModelConfig` and `RFGeminiAPIModelConfig` to be defined whenever evals modules are available, even if `vllm` cannot be installed, while keeping `RFvLLMModelConfig` gated behind `_VLLM_AVAILABLE`.
> 
> Updates evals scheduling/serialization code paths to guard `isinstance()` checks and class tuples when these optional config classes are `None`, preventing crashes on platforms without vLLM and ensuring pipeline type/model-name inference continues to work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6e9d8baa62225e7c0136ebfddce416c80f95454. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->