### PR TITLE
Print out URLs for VS Code/Cursor auto detect port forwarding

### DIFF
--- a/rapidfireai/cli.py
+++ b/rapidfireai/cli.py
@@ -464,6 +464,7 @@ def run_jupyter():
     app = ServerApp()
     app.open_browser = False
     app.port = JupyterConfig.PORT
+    app.ip = JupyterConfig.HOST
     app.allow_origin = '*'
     app.websocket_ping_interval = 90000
     app.log_level = 'CRITICAL'
@@ -488,9 +489,9 @@ def run_jupyter():
         mlflow_port = MLflowConfig.PORT
 
         if os.getenv("TERM_PROGRAM") == "vscode":
-            print(f"VSCode detected, port {app.port} should automatically be forwarded to localhost")
-            print(f"Manually forward port {dispatcher_port} to localhost, using the Ports tab in VSCode/Cursor/etc.")
-            print(f"Manually forward port {mlflow_port} to localhost, using the Ports tab in VSCode/Cursor/etc.")
+            print(f"VSCode detected, port {app.port} (tcp://{app.ip}:{app.port}) should automatically be forwarded to localhost")
+            print(f"Manually forward port {dispatcher_port} (tcp://{DispatcherConfig.HOST}:{dispatcher_port}) to localhost, using the Ports tab in VSCode/Cursor/etc.")
+            print(f"Manually forward port {mlflow_port} (tcp://{MLflowConfig.HOST}:{mlflow_port}) to localhost, using the Ports tab in VSCode/Cursor/etc.")
         else:
             os_username = os.getenv("USER", os.getenv("LOGNAME", "username"))
             print(f"Manually forward port {app.port} to localhost")

--- a/setup/start.sh
+++ b/setup/start.sh
@@ -347,7 +347,7 @@ wait_for_service() {
     local max_attempts=${4:-$RF_TIMEOUT_TIME}  # Allow custom timeout, default 30 seconds
     local attempt=1
 
-    print_status "Waiting for $service to be ready on $host:$port (timeout: ${max_attempts} attempts)..."
+    print_status "Waiting for $service to be ready on tcp://$host:$port (timeout: ${max_attempts} attempts)..."
 
     if command -v nc &> /dev/null; then
         ping_command="$(command -v nc) -z $host $port"


### PR DESCRIPTION
## Changes
- Output ports using tcp:// to allow auto port forwarding of VS Code/Cursor

## Changelog Content

### Changes
- Output ports using tcp:// to allow auto port forwarding of VS Code/Cursor


## Related Issues
Closes RapidFireAI Pro Issue 64


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 9e085da6b33221a64f8fee2c53b037d1c656d407. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->