### PR TITLE
Change compute capability detection to a warning and disabled if no GPU

### DIFF
--- a/rapidfireai/cli.py
+++ b/rapidfireai/cli.py
@@ -355,13 +355,14 @@ def install_packages(
                 compute_cap = get_compute_capability()
                 if compute_cap is None:
                     print(
-                        "❌ Could not detect GPU compute capability (nvidia-smi unavailable or failed).\n"
+                        "⚠️ Could not detect GPU compute capability (nvidia-smi unavailable or failed).\n"
+                        "   Disabling CUDA usage for evaluation dependencies.\n"
                         "   Pass it explicitly, for example:\n"
                         "   rapidfireai init --evals --computecapabilityversion 8.0\n"
                         "   (Use your GPU's SM version, e.g. 8.9 for Ada, 9.0 for Blackwell.)",
                         file=sys.stderr,
                     )
-                    return 1
+                    compute_cap = 0.0
             if compute_cap is not None and compute_cap >= 8.0:
                 packages.append({"package": "flash-attn>=2.8.3", "extra_args": ["--upgrade", "--no-build-isolation"]})
                 # Re-install torch, torchvision, and torchaudio to ensure compatibility as flash-attn requires an old version of torch but will upgrade torch to an incompatible version


### PR DESCRIPTION


## Changes
- If not GPU or Nvidia check fails change error to a warning and disable GPU tasks

## Changelog Content
### Changes
- If not GPU or Nvidia check fails change error to a warning and disable GPU tasks


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes `rapidfireai init --evals` behavior when GPU compute capability detection fails, avoiding a hard failure and skipping CUDA-specific installs like `flash-attn`.
> 
> **Overview**
> `rapidfireai init --evals` no longer hard-fails when GPU compute capability can’t be detected via `nvidia-smi`. Instead it emits a warning and forces `compute_cap` to `0.0`, effectively disabling CUDA-specific evaluation dependency steps that require a known compute capability (e.g., gating `flash-attn` installation).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 228cc2d844f22b2f8fc835b89a54e04047f1dbc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->