### PR TITLE
Cpu plain torch

### DIFF
--- a/rapidfireai/cli.py
+++ b/rapidfireai/cli.py
@@ -283,7 +283,8 @@ def install_packages(
         torchvision_version = "0.23.0"
         torchaudio_version = "2.8.0"
         torch_cuda = "cpu"
-    if cuda_major==12:
+
+    elif cuda_major==12:
         if cuda_minor>=9:
             # Supports Torch 2.8.0
             torch_version = "2.8.0"

--- a/rapidfireai/cli.py
+++ b/rapidfireai/cli.py
@@ -201,13 +201,36 @@ def install_packages(
         print(
             " ⚠️ Could not detect CUDA (nvcc and nvidia-smi unavailable or failed).\n"
             "    Disabling CUDA usage for evaluation dependencies.\n"
-            "    If you want to override this expelicitly pass the CUDA version, for example:\n"
+            "    If you want to override this explicitly pass the CUDA version, for example:\n"
             "        rapidfireai init --evals --cudaversion 12.4\n"
             "    If nvidia-smi is unavailable, also pass --computecapabilityversion (see --help).\n"
             "          If there is no GPU available, you can ignore this warning.",
             file=sys.stderr,
         )
-
+        compute_capability_version = "0.0"
+    if compute_capability_version is not None:
+        compute_cap = parse_compute_capability_string(compute_capability_version)
+        if compute_cap is None:
+            print(
+                "❌ Invalid --computecapabilityversion: use major.minor (e.g. 8.0 or 8.6).",
+                file=sys.stderr,
+            )
+            return 1
+    else:
+        compute_cap = get_compute_capability()
+        if compute_cap is None:
+            print(
+                "⚠️ Could not detect GPU compute capability (nvidia-smi unavailable or failed).\n"
+                "   Disabling CUDA usage for evaluation dependencies.\n"
+                "   Pass it explicitly, for example:\n"
+                "   rapidfireai init --evals --computecapabilityversion 8.0\n"
+                "   (Use your GPU's SM version, e.g. 8.9 for Ada, 9.0 for Blackwell.)\n"
+                "          If there is no GPU available, you can ignore this warning.",
+                file=sys.stderr,
+            )
+            compute_cap = 0.0
+            cuda_major = 0
+            cuda_minor = 0
     python_info = get_python_info()
     site_packages = python_info["site_packages"]
     setup_directory = None
@@ -255,6 +278,11 @@ def install_packages(
     torchaudio_version = "2.5.1"
     torch_cuda = "cu121"
     flash_cuda = "cu121"
+    if cuda_major==0:
+        torch_version = "2.8.0"
+        torchvision_version = "0.23.0"
+        torchaudio_version = "2.8.0"
+        torch_cuda = "cpu"
     if cuda_major==12:
         if cuda_minor>=9:
             # Supports Torch 2.8.0
@@ -323,6 +351,12 @@ def install_packages(
 
     
     ## TODO: re-enable for fit once trl has fix
+    if not ColabConfig.ON_COLAB and cuda_major==0:
+        print(f"\n🎯 Using CPU, using {torch_cuda}")
+        packages.append({"package": f"torch=={torch_version}", "extra_args": ["--upgrade"]})
+        packages.append({"package": f"torchvision=={torchvision_version}", "extra_args": ["--upgrade"]})
+        packages.append({"package": f"torchaudio=={torchaudio_version}", "extra_args": ["--upgrade"]})
+
     if not ColabConfig.ON_COLAB and cuda_major >= 12:
         if cuda_from_user:
             print(f"\n🎯 Using CUDA {cuda_major}.{cuda_minor} (from --cudaversion), using {torch_cuda}")
@@ -343,26 +377,7 @@ def install_packages(
             packages.append({"package": f"torch=={torch_version}", "extra_args": ["--upgrade", "--index-url", f"https://download.pytorch.org/whl/{torch_cuda}"]})
             packages.append({"package": f"torchvision=={torchvision_version}", "extra_args": ["--upgrade", "--index-url", f"https://download.pytorch.org/whl/{torch_cuda}"]})
             packages.append({"package": f"torchaudio=={torchaudio_version}", "extra_args": ["--upgrade", "--index-url", f"https://download.pytorch.org/whl/{torch_cuda}"]})
-            if compute_capability_version is not None:
-                compute_cap = parse_compute_capability_string(compute_capability_version)
-                if compute_cap is None:
-                    print(
-                        "❌ Invalid --computecapabilityversion: use major.minor (e.g. 8.0 or 8.6).",
-                        file=sys.stderr,
-                    )
-                    return 1
-            else:
-                compute_cap = get_compute_capability()
-                if compute_cap is None:
-                    print(
-                        "⚠️ Could not detect GPU compute capability (nvidia-smi unavailable or failed).\n"
-                        "   Disabling CUDA usage for evaluation dependencies.\n"
-                        "   Pass it explicitly, for example:\n"
-                        "   rapidfireai init --evals --computecapabilityversion 8.0\n"
-                        "   (Use your GPU's SM version, e.g. 8.9 for Ada, 9.0 for Blackwell.)",
-                        file=sys.stderr,
-                    )
-                    compute_cap = 0.0
+
             if compute_cap is not None and compute_cap >= 8.0:
                 packages.append({"package": "flash-attn>=2.8.3", "extra_args": ["--upgrade", "--no-build-isolation"]})
                 # Re-install torch, torchvision, and torchaudio to ensure compatibility as flash-attn requires an old version of torch but will upgrade torch to an incompatible version

--- a/rapidfireai/cli.py
+++ b/rapidfireai/cli.py
@@ -352,10 +352,15 @@ def install_packages(
     
     ## TODO: re-enable for fit once trl has fix
     if not ColabConfig.ON_COLAB and cuda_major==0:
-        print(f"\n🎯 Using CPU, using {torch_cuda}")
+        print(f"\n🎯 Using CPU")
         packages.append({"package": f"torch=={torch_version}", "extra_args": ["--upgrade"]})
         packages.append({"package": f"torchvision=={torchvision_version}", "extra_args": ["--upgrade"]})
         packages.append({"package": f"torchaudio=={torchaudio_version}", "extra_args": ["--upgrade"]})
+    
+    if cuda_major >= 12:
+        packages.append({"package": f"faiss-gpu-cu12", "extra_args": ["--upgrade"]})
+    else:
+        packages.append({"package": f"faiss-cpu", "extra_args": ["--upgrade"]})
 
     if not ColabConfig.ON_COLAB and cuda_major >= 12:
         if cuda_from_user:

--- a/rapidfireai/utils/doctor.py
+++ b/rapidfireai/utils/doctor.py
@@ -87,6 +87,7 @@ def get_doctor_info(log_lines: int = 10):
             "rf-faiss",
             "rf-faiss-gpu-12-8",
             "faiss-gpu-cu12",
+            "faiss-cpu",
             "vllm",
             "flash-attn",
             "flash_attn",

--- a/setup/evals/requirements-colab.txt
+++ b/setup/evals/requirements-colab.txt
@@ -37,7 +37,6 @@ unstructured>=0.18.15
 # Other
 requests==2.32.5
 vllm==0.11.0
-faiss-gpu-cu12
 fsspec>=2023.1.0,<=2025.3.0
 # flashinfer excluded: v0.5.x requires compute capability >= 8.0 (sm_80+)
 # Colab T4 is sm_75; flashinfer's CUTLASS CuTE DSL also JIT-compiles at import

--- a/setup/evals/requirements-local.txt
+++ b/setup/evals/requirements-local.txt
@@ -40,7 +40,6 @@ requests==2.32.5
 datasets
 jupyter
 grpcio
-faiss-gpu-cu12
 
 # MLflow Dashboard dependencies
 mlflow>=3.11.1

--- a/setup/evals/requirements.txt
+++ b/setup/evals/requirements.txt
@@ -33,7 +33,6 @@ langchain-huggingface
 langchain-google-genai>=4.2.1
 
 # Vector Search
-faiss-gpu
 
 # Statistical Analysis
 scipy

--- a/setup/fit/requirements-local.txt
+++ b/setup/fit/requirements-local.txt
@@ -34,8 +34,6 @@ langchain-openai
 langchain-huggingface
 langchain-google-genai>=4.2.1
 
-# Vector Search
-faiss-gpu-cu12==1.13.0
 
 # Statistical Analysis
 scipy>=1.16.1


### PR DESCRIPTION
## Changes
- Support install and init on a non-Nvidia GPU machine

## Changelog Content.
### Changes
- Support install and init on a non-Nvidia GPU machine
- Installs faiss-cpu on a non-Nvidia machine
### Fixes
- Install issues on systems with CUDA and without a Nvidia GPU



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes package installation and dependency selection paths for both CPU-only and CUDA setups, which can impact environment reproducibility and runtime compatibility. Risk is moderate because it affects core init flows and pinned ML stack versions but is largely additive and guarded by detection/flags.
> 
> **Overview**
> Adds a **CPU-only fallback path** to `rapidfireai init`, including explicit handling of missing CUDA *and* missing GPU compute capability so non-NVIDIA machines don’t attempt CUDA-only eval dependencies.
> 
> `install_packages` now selects a CPU PyTorch stack when CUDA is disabled/undetected and installs `faiss-cpu` instead of `faiss-gpu-cu12` when CUDA < 12. Requirements files are adjusted to remove hardcoded FAISS GPU deps, and `doctor`’s relevant package list now includes `faiss-cpu`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eccf457ff286c8bb219595f7ad4ac4f0e34b666c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->