### PR TITLE
Set MLFLOW_TRACKING_URI

### DIFF
--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -1,0 +1,2 @@
+# General
+* Report all issues found across all changed files in a single review.

--- a/.gitignore
+++ b/.gitignore
@@ -201,7 +201,7 @@ cython_debug/
 .cursor/
 .cursorignore
 .cursorindexingignore
-!.cursor/BUGBOT.md
+
 
 # Marimo
 marimo/_static/

--- a/.gitignore
+++ b/.gitignore
@@ -201,6 +201,7 @@ cython_debug/
 .cursor/
 .cursorignore
 .cursorindexingignore
+!./cursor/BUGBOT.md
 
 # Marimo
 marimo/_static/

--- a/.gitignore
+++ b/.gitignore
@@ -201,7 +201,7 @@ cython_debug/
 .cursor/
 .cursorignore
 .cursorindexingignore
-!./cursor/BUGBOT.md
+!.cursor/BUGBOT.md
 
 # Marimo
 marimo/_static/

--- a/rapidfireai/frontend/src/gateway/components/endpoints/EndpointUsageModal.test.tsx
+++ b/rapidfireai/frontend/src/gateway/components/endpoints/EndpointUsageModal.test.tsx
@@ -17,7 +17,7 @@ describe('EndpointUsageModal', () => {
     open: true,
     onClose: jest.fn(),
     endpointName: 'test-endpoint',
-    baseUrl: 'http://localhost:5000',
+    baseUrl: 'http://localhost:8852',
   };
 
   test('renders modal with title when open', () => {

--- a/rapidfireai/frontend/src/gateway/components/endpoints/EndpointUsageModal.tsx
+++ b/rapidfireai/frontend/src/gateway/components/endpoints/EndpointUsageModal.tsx
@@ -16,6 +16,10 @@ import { CopyButton } from '@mlflow/mlflow/src/shared/building_blocks/CopyButton
 import { CodeSnippet } from '@databricks/web-shared/snippet';
 import { TryItPanel } from './TryItPanel';
 
+const rfMlflowHost: string = process.env.RF_MLFLOW_HOST || 'localhost';
+const rfMlflowPort: string = process.env.RF_MLFLOW_PORT || '8852';
+const rfMlflowUrl: string = `http://${rfMlflowHost}:${rfMlflowPort}/`;
+
 type Provider = 'openai' | 'anthropic' | 'gemini';
 type Language = 'curl' | 'python';
 
@@ -31,7 +35,7 @@ const getBaseUrl = (baseUrl?: string): string => {
   if (typeof window !== 'undefined') {
     return window.location.origin;
   }
-  return 'http://localhost:5000';
+  return rfMlflowUrl
 };
 
 type TryItUnifiedVariant = 'mlflow-invocations' | 'chat-completions';

--- a/rapidfireai/frontend/src/gateway/components/endpoints/EndpointUsageModal.tsx
+++ b/rapidfireai/frontend/src/gateway/components/endpoints/EndpointUsageModal.tsx
@@ -18,7 +18,7 @@ import { TryItPanel } from './TryItPanel';
 
 const rfMlflowHost: string = process.env.RF_MLFLOW_HOST || 'localhost';
 const rfMlflowPort: string = process.env.RF_MLFLOW_PORT || '8852';
-const rfMlflowUrl: string = `http://${rfMlflowHost}:${rfMlflowPort}/`;
+const rfMlflowUrl: string = `http://${rfMlflowHost}:${rfMlflowPort}`;
 
 type Provider = 'openai' | 'anthropic' | 'gemini';
 type Language = 'curl' | 'python';

--- a/rapidfireai/frontend/src/gateway/components/endpoints/TryItPanel.test.tsx
+++ b/rapidfireai/frontend/src/gateway/components/endpoints/TryItPanel.test.tsx
@@ -49,7 +49,7 @@ describe('Try it tab', () => {
     open: true,
     onClose: jest.fn(),
     endpointName: 'test-endpoint',
-    baseUrl: 'http://localhost:5000',
+    baseUrl: 'http://localhost:8852',
   };
 
   let fetchSpy: ReturnType<typeof jest.spyOn>;

--- a/setup/fit/start_dev.sh
+++ b/setup/fit/start_dev.sh
@@ -221,7 +221,11 @@ start_mlflow() {
     # Start MLflow server in background with process group
     # Set tracking URI so the gateway's internal tracing sends traces via HTTP
     # rather than trying to use the SQLite backend-store URI directly.
-    export MLFLOW_TRACKING_URI="http://$RF_MLFLOW_HOST:$RF_MLFLOW_PORT"
+    if [[ "$RF_MLFLOW_HOST" == "0.0.0.0" ]]; then
+        export MLFLOW_TRACKING_URI="http://localhost:$RF_MLFLOW_PORT"
+    else
+        export MLFLOW_TRACKING_URI="http://$RF_MLFLOW_HOST:$RF_MLFLOW_PORT"
+    fi
 
     # Use setsid on Linux, nohup on macOS
     if command -v setsid &> /dev/null; then

--- a/setup/fit/start_dev.sh
+++ b/setup/fit/start_dev.sh
@@ -219,6 +219,10 @@ start_mlflow() {
     fi
 
     # Start MLflow server in background with process group
+    # Set tracking URI so the gateway's internal tracing sends traces via HTTP
+    # rather than trying to use the SQLite backend-store URI directly.
+    export MLFLOW_TRACKING_URI="http://$RF_MLFLOW_HOST:$RF_MLFLOW_PORT"
+
     # Use setsid on Linux, nohup on macOS
     if command -v setsid &> /dev/null; then
         setsid mlflow server \

--- a/setup/start.sh
+++ b/setup/start.sh
@@ -380,6 +380,10 @@ start_mlflow() {
     # Start MLflow server in background with logging
     print_status "MLflow logs will be written to: $RF_LOG_PATH/mlflow.log"
 
+    # Set tracking URI so the gateway's internal tracing sends traces via HTTP
+    # rather than trying to use the SQLite backend-store URI directly.
+    export MLFLOW_TRACKING_URI="http://$RF_MLFLOW_HOST:$RF_MLFLOW_PORT"
+
     # Use setsid on Linux, nohup on macOS
     if command -v setsid &> /dev/null; then
         setsid mlflow server \

--- a/setup/start.sh
+++ b/setup/start.sh
@@ -382,7 +382,11 @@ start_mlflow() {
 
     # Set tracking URI so the gateway's internal tracing sends traces via HTTP
     # rather than trying to use the SQLite backend-store URI directly.
-    export MLFLOW_TRACKING_URI="http://$RF_MLFLOW_HOST:$RF_MLFLOW_PORT"
+    if [[ "$RF_MLFLOW_HOST" == "0.0.0.0" ]]; then
+        export MLFLOW_TRACKING_URI="http://localhost:$RF_MLFLOW_PORT"
+    else
+        export MLFLOW_TRACKING_URI="http://$RF_MLFLOW_HOST:$RF_MLFLOW_PORT"
+    fi
 
     # Use setsid on Linux, nohup on macOS
     if command -v setsid &> /dev/null; then


### PR DESCRIPTION
## Changes
- Explicitly set MLFLOW_TRACKING_URI to eliminate warning in MLflow log file

## Changelog Content

### Fixes
- Explicitly set MLFLOW_TRACKING_URI to eliminate warning in MLflow log file



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to dev/startup scripts and frontend example URL defaults; main runtime logic and data handling are unaffected, with only minor risk of misconfigured env vars affecting local startup.
> 
> **Overview**
> Sets `MLFLOW_TRACKING_URI` before launching the MLflow server in both `setup/start.sh` and `setup/fit/start_dev.sh`, choosing `localhost` when binding to `0.0.0.0`, to ensure gateway tracing talks to MLflow over HTTP instead of the SQLite backend URI (and avoid related warnings).
> 
> Updates the gateway endpoint usage UI fallback base URL and associated tests to default to `http://localhost:8852` (and optionally derive it from `RF_MLFLOW_HOST`/`RF_MLFLOW_PORT`) rather than the previous `localhost:5000`, keeping local examples aligned with the default MLflow port.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7cbd42f599d3b62ce149e57c46aa42083d6005e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->