### PR TITLE
Fix mlflow variables

### DIFF
--- a/rapidfireai/frontend/src/gateway/components/endpoints/EndpointUsageModal.tsx
+++ b/rapidfireai/frontend/src/gateway/components/endpoints/EndpointUsageModal.tsx
@@ -16,8 +16,8 @@ import { CopyButton } from '@mlflow/mlflow/src/shared/building_blocks/CopyButton
 import { CodeSnippet } from '@databricks/web-shared/snippet';
 import { TryItPanel } from './TryItPanel';
 
-const rfMlflowHost: string = process.env.RF_MLFLOW_HOST || 'localhost';
-const rfMlflowPort: string = process.env.RF_MLFLOW_PORT || '8852';
+const rfMlflowHost: string = process.env["RF_MLFLOW_HOST"] || 'localhost';
+const rfMlflowPort: string = process.env["RF_MLFLOW_PORT"] || '8852';
 const rfMlflowUrl: string = `http://${rfMlflowHost}:${rfMlflowPort}`;
 
 type Provider = 'openai' | 'anthropic' | 'gemini';


### PR DESCRIPTION
## Changes
- Fix issue from PR #248 

## Related Issues
Related to PR #248 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small UI-side change that only affects how `RF_MLFLOW_HOST`/`RF_MLFLOW_PORT` are read to construct the fallback MLflow base URL.
> 
> **Overview**
> Fixes MLflow configuration lookup in `EndpointUsageModal` by switching `process.env.RF_MLFLOW_HOST/PORT` to `process.env["RF_MLFLOW_HOST"]/PORT`, ensuring the modal builds `rfMlflowUrl` from the intended environment variables (with the same `localhost:8852` fallback).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32f13e110dd8a8b72d3a30ce03a7f8cbb50aa3a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->