### PR TITLE
MultiModal Install

### DIFF
--- a/rapidfireai/cli.py
+++ b/rapidfireai/cli.py
@@ -162,6 +162,180 @@ def parse_compute_capability_string(cap: str) -> float | None:
     return major + minor / 10.0
 
 
+# Canonical (Debian/Ubuntu) package name -> per-package-manager native name.
+# Used by the `--multimodal` init option to install OS dependencies required by
+# `unstructured[all-docs]` (PDF / OCR / XML toolchain).
+_MULTIMODAL_OS_PACKAGES = {
+    "libmagic1":    {"apt": "libmagic1",    "dnf": "file-libs",     "yum": "file-libs",     "pacman": "file",     "zypper": "file-magic",   "brew": "libmagic"},
+    "poppler-utils":{"apt": "poppler-utils","dnf": "poppler-utils", "yum": "poppler-utils", "pacman": "poppler",  "zypper": "poppler-tools","brew": "poppler"},
+    "tesseract-ocr":{"apt": "tesseract-ocr","dnf": "tesseract",     "yum": "tesseract",     "pacman": "tesseract","zypper": "tesseract-ocr","brew": "tesseract"},
+    "libxml2":      {"apt": "libxml2",      "dnf": "libxml2",       "yum": "libxml2",       "pacman": "libxml2",  "zypper": "libxml2-2",    "brew": "libxml2"},
+    "libxslt1-dev": {"apt": "libxslt1-dev", "dnf": "libxslt-devel", "yum": "libxslt-devel", "pacman": "libxslt",  "zypper": "libxslt-devel","brew": "libxslt"},
+    "wget":         {"apt": "wget",         "dnf": "wget",          "yum": "wget",          "pacman": "wget",     "zypper": "wget",         "brew": "wget"},
+    "unrar":        {"apt": "unrar",        "dnf": "unrar",         "yum": "unrar",         "pacman": "unrar",    "zypper": "unrar",        "brew": "unrar"},
+}
+
+
+def _detect_pkg_manager():
+    """Detect the OS package manager.
+
+    Returns (manager, distro_id). ``manager`` is one of
+    ``apt``/``dnf``/``yum``/``pacman``/``zypper``/``brew`` or ``None`` if
+    nothing supported is available.
+    """
+    system = platform.system()
+    if system == "Darwin":
+        return ("brew" if shutil.which("brew") else None, "macos")
+    if system != "Linux":
+        return (None, system.lower())
+
+    try:
+        import distro  # type: ignore
+        dist_id = (distro.id() or "").lower()
+    except Exception:
+        dist_id = ""
+
+    debian_like = {"debian", "ubuntu", "linuxmint", "pop", "kali", "raspbian", "elementary"}
+    rhel_like = {"rhel", "centos", "fedora", "rocky", "almalinux", "amzn", "ol"}
+    arch_like = {"arch", "manjaro", "endeavouros"}
+    suse_like = {"opensuse", "opensuse-leap", "opensuse-tumbleweed", "sles"}
+
+    if dist_id in debian_like and shutil.which("apt-get"):
+        return ("apt", dist_id)
+    if dist_id in rhel_like:
+        if shutil.which("dnf"):
+            return ("dnf", dist_id)
+        if shutil.which("yum"):
+            return ("yum", dist_id)
+    if dist_id in arch_like and shutil.which("pacman"):
+        return ("pacman", dist_id)
+    if dist_id in suse_like and shutil.which("zypper"):
+        return ("zypper", dist_id)
+
+    for mgr, cmd in (("apt", "apt-get"), ("dnf", "dnf"), ("yum", "yum"),
+                      ("pacman", "pacman"), ("zypper", "zypper")):
+        if shutil.which(cmd):
+            return (mgr, dist_id)
+
+    return (None, dist_id)
+
+
+def _is_os_pkg_installed(manager: str, name: str) -> bool:
+    """Return True if an OS package is installed via the given package manager."""
+    try:
+        if manager == "apt":
+            r = subprocess.run(["dpkg", "-s", name], capture_output=True, text=True, check=False)
+            return r.returncode == 0 and "Status: install ok installed" in r.stdout
+        if manager in ("dnf", "yum", "zypper"):
+            r = subprocess.run(["rpm", "-q", name], capture_output=True, text=True, check=False)
+            return r.returncode == 0
+        if manager == "pacman":
+            r = subprocess.run(["pacman", "-Q", name], capture_output=True, text=True, check=False)
+            return r.returncode == 0
+        if manager == "brew":
+            r = subprocess.run(["brew", "list", "--formula", name], capture_output=True, text=True, check=False)
+            return r.returncode == 0
+    except FileNotFoundError:
+        return False
+    return False
+
+
+def _build_install_cmd(manager: str, names: list[str]) -> list[str] | None:
+    """Build the install command for the given package manager."""
+    if manager == "apt":
+        return ["sudo", "apt-get", "install", "-y"] + names
+    if manager == "dnf":
+        return ["sudo", "dnf", "install", "-y"] + names
+    if manager == "yum":
+        return ["sudo", "yum", "install", "-y"] + names
+    if manager == "pacman":
+        return ["sudo", "pacman", "-S", "--noconfirm", "--needed"] + names
+    if manager == "zypper":
+        return ["sudo", "zypper", "--non-interactive", "install"] + names
+    if manager == "brew":
+        # Homebrew explicitly refuses to run under sudo.
+        return ["brew", "install"] + names
+    return None
+
+
+def install_multimodal_system_packages() -> int:
+    """Ensure OS packages needed for multimodal document parsing are installed.
+
+    Checks for ``libmagic1``, ``poppler-utils``, ``tesseract-ocr``, ``libxml2``,
+    ``libxslt1-dev``, ``wget`` and ``unrar`` (mapped to the equivalent package
+    names on non-Debian distros / macOS). Missing packages are installed via
+    ``sudo`` and the detected package manager. On failure or when no supported
+    package manager is detected, a warning is printed and the function returns
+    non-zero without raising so the rest of init can continue.
+    """
+    canonical_pkgs = list(_MULTIMODAL_OS_PACKAGES.keys())
+    manager, dist_id = _detect_pkg_manager()
+    if manager is None:
+        print("⚠️ Could not detect a supported OS package manager for multimodal dependencies.")
+        print("   Please install the following packages manually using sudo or the equivalent")
+        print(f"   for your operating system: {', '.join(canonical_pkgs)}")
+        return 1
+
+    native_names = [_MULTIMODAL_OS_PACKAGES[p].get(manager, p) for p in canonical_pkgs]
+    missing = [n for n in native_names if not _is_os_pkg_installed(manager, n)]
+    if not missing:
+        print(f"✅ All multimodal system dependencies already installed (via {manager})")
+        return 0
+
+    print(f"📦 Installing missing multimodal system dependencies via {manager}: {', '.join(missing)}")
+
+    if manager == "apt":
+        # Refresh the package index so package names like ``libxslt1-dev`` resolve.
+        try:
+            subprocess.run(["sudo", "apt-get", "update"], check=False)
+        except FileNotFoundError:
+            pass
+
+    cmd = _build_install_cmd(manager, missing)
+    if cmd is None:
+        print(f"⚠️ No install command available for package manager '{manager}'.")
+        print(f"   Please install these packages manually: {', '.join(missing)}")
+        return 1
+
+    try:
+        subprocess.run(cmd, check=True)
+    except subprocess.CalledProcessError as e:
+        print(f"⚠️ Failed to install multimodal system dependencies (exit code {e.returncode}).")
+        print("   Please install them manually with sudo or the equivalent for your OS:")
+        print(f"   $ {' '.join(cmd)}")
+        return 1
+    except FileNotFoundError as e:
+        print(f"⚠️ Could not run installer ({e}).")
+        print("   Please install these packages manually with sudo or the equivalent for your OS:")
+        print(f"     {', '.join(missing)}")
+        return 1
+
+    print("✅ Successfully installed multimodal system dependencies")
+    return 0
+
+
+def install_multimodal_python_packages() -> int:
+    """Install the Python packages required for multimodal document parsing."""
+    packages = ["unstructured[all-docs]", "nltk"]
+    print("📦 Installing multimodal Python packages...")
+    for pkg in packages:
+        cmd = [sys.executable, "-m", "uv", "pip", "install", "--upgrade", pkg]
+        print(f"   Installing {pkg}...")
+        try:
+            subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=True)
+            print(f"✅ Successfully installed {pkg}")
+        except subprocess.CalledProcessError as e:
+            print(f"❌ Failed to install {pkg}")
+            print(f"   Error: {e}")
+            if e.stdout:
+                print(f"   Standard output: {e.stdout}")
+            if e.stderr:
+                print(f"   Standard error: {e.stderr}")
+            print(f"   You may need to install {pkg} manually")
+            return 1
+    return 0
+
+
 def install_packages(
     evals: bool = False,
     init_packages: list[str] | None = None,
@@ -435,12 +609,26 @@ def copy_tutorial_notebooks():
 
 def run_init(
     evals: bool = False,
+    multimodal: bool = False,
     cuda_version: str | None = None,
     compute_capability_version: str | None = None,
 ):
     """Run the init command to initialize the project."""
     print("🔧 Initializing RapidFire AI project...")
     print("-" * 30)
+
+    if multimodal and not evals:
+        print("⚠️ --multimodal requires --evals; ignoring --multimodal.")
+        multimodal = False
+
+    if multimodal:
+        print("Setting up multimodal document parsing dependencies...")
+        # System-package install failures are non-fatal: warnings are printed
+        # so the user can install manually, but init continues.
+        install_multimodal_system_packages()
+        if install_multimodal_python_packages() != 0:
+            return 1
+
     print("Initializing project...")
     if (
         install_packages(
@@ -577,6 +765,9 @@ Examples:
   # Basic Initialize with evaluation dependencies
   rapidfireai init --evals
 
+  # Initialize with evaluation + multimodal document parsing dependencies
+  rapidfireai init --evals --multimodal
+
   # Init when nvcc/nvidia-smi are unavailable (pin CUDA / compute capability)
   rapidfireai init --evals --cudaversion 12.4 --computecapabilityversion 8.0
   
@@ -637,6 +828,14 @@ For more information, visit: https://github.com/RapidFireAI/rapidfireai
     parser.add_argument("--force", "-f", action="store_true", help="Force action without confirmation")
 
     parser.add_argument("--evals", action="store_true", help="Initialize with evaluation dependencies")
+
+    parser.add_argument(
+        "--multimodal",
+        action="store_true",
+        help="(Only with --evals) Install OS dependencies (libmagic1, poppler-utils, tesseract-ocr, "
+             "libxml2, libxslt1-dev, wget, unrar) and Python packages (unstructured[all-docs], nltk) "
+             "needed for multimodal document parsing.",
+    )
 
     parser.add_argument(
         "--cudaversion",
@@ -701,6 +900,7 @@ For more information, visit: https://github.com/RapidFireAI/rapidfireai
     if args.command == "init":
         return run_init(
             args.evals,
+            multimodal=args.multimodal,
             cuda_version=args.cuda_version,
             compute_capability_version=args.compute_capability_version,
         )

--- a/rapidfireai/cli.py
+++ b/rapidfireai/cli.py
@@ -162,102 +162,6 @@ def parse_compute_capability_string(cap: str) -> float | None:
     return major + minor / 10.0
 
 
-# Canonical (Debian/Ubuntu) package name -> per-package-manager native name.
-# Used by the `--multimodal` init option to install OS dependencies required by
-# `unstructured[all-docs]` (PDF / OCR / XML toolchain).
-_MULTIMODAL_OS_PACKAGES = {
-    "libmagic1":    {"apt": "libmagic1",    "dnf": "file-libs",     "yum": "file-libs",     "pacman": "file",     "zypper": "file-magic",   "brew": "libmagic"},
-    "poppler-utils":{"apt": "poppler-utils","dnf": "poppler-utils", "yum": "poppler-utils", "pacman": "poppler",  "zypper": "poppler-tools","brew": "poppler"},
-    "tesseract-ocr":{"apt": "tesseract-ocr","dnf": "tesseract",     "yum": "tesseract",     "pacman": "tesseract","zypper": "tesseract-ocr","brew": "tesseract"},
-    "libxml2":      {"apt": "libxml2",      "dnf": "libxml2",       "yum": "libxml2",       "pacman": "libxml2",  "zypper": "libxml2-2",    "brew": "libxml2"},
-    "libxslt1-dev": {"apt": "libxslt1-dev", "dnf": "libxslt-devel", "yum": "libxslt-devel", "pacman": "libxslt",  "zypper": "libxslt-devel","brew": "libxslt"},
-    "wget":         {"apt": "wget",         "dnf": "wget",          "yum": "wget",          "pacman": "wget",     "zypper": "wget",         "brew": "wget"},
-    "unrar":        {"apt": "unrar",        "dnf": "unrar",         "yum": "unrar",         "pacman": "unrar",    "zypper": "unrar",        "brew": "unrar"},
-}
-
-
-def _detect_pkg_manager():
-    """Detect the OS package manager.
-
-    Returns (manager, distro_id). ``manager`` is one of
-    ``apt``/``dnf``/``yum``/``pacman``/``zypper``/``brew`` or ``None`` if
-    nothing supported is available.
-    """
-    system = platform.system()
-    if system == "Darwin":
-        return ("brew" if shutil.which("brew") else None, "macos")
-    if system != "Linux":
-        return (None, system.lower())
-
-    try:
-        import distro  # type: ignore
-        dist_id = (distro.id() or "").lower()
-    except Exception:
-        dist_id = ""
-
-    debian_like = {"debian", "ubuntu", "linuxmint", "pop", "kali", "raspbian", "elementary"}
-    rhel_like = {"rhel", "centos", "fedora", "rocky", "almalinux", "amzn", "ol"}
-    arch_like = {"arch", "manjaro", "endeavouros"}
-    suse_like = {"opensuse", "opensuse-leap", "opensuse-tumbleweed", "sles"}
-
-    if dist_id in debian_like and shutil.which("apt-get"):
-        return ("apt", dist_id)
-    if dist_id in rhel_like:
-        if shutil.which("dnf"):
-            return ("dnf", dist_id)
-        if shutil.which("yum"):
-            return ("yum", dist_id)
-    if dist_id in arch_like and shutil.which("pacman"):
-        return ("pacman", dist_id)
-    if dist_id in suse_like and shutil.which("zypper"):
-        return ("zypper", dist_id)
-
-    for mgr, cmd in (("apt", "apt-get"), ("dnf", "dnf"), ("yum", "yum"),
-                      ("pacman", "pacman"), ("zypper", "zypper")):
-        if shutil.which(cmd):
-            return (mgr, dist_id)
-
-    return (None, dist_id)
-
-
-def _is_os_pkg_installed(manager: str, name: str) -> bool:
-    """Return True if an OS package is installed via the given package manager."""
-    try:
-        if manager == "apt":
-            r = subprocess.run(["dpkg", "-s", name], capture_output=True, text=True, check=False)
-            return r.returncode == 0 and "Status: install ok installed" in r.stdout
-        if manager in ("dnf", "yum", "zypper"):
-            r = subprocess.run(["rpm", "-q", name], capture_output=True, text=True, check=False)
-            return r.returncode == 0
-        if manager == "pacman":
-            r = subprocess.run(["pacman", "-Q", name], capture_output=True, text=True, check=False)
-            return r.returncode == 0
-        if manager == "brew":
-            r = subprocess.run(["brew", "list", "--formula", name], capture_output=True, text=True, check=False)
-            return r.returncode == 0
-    except FileNotFoundError:
-        return False
-    return False
-
-
-def _build_install_cmd(manager: str, names: list[str]) -> list[str] | None:
-    """Build the install command for the given package manager."""
-    if manager == "apt":
-        return ["sudo", "apt-get", "install", "-y"] + names
-    if manager == "dnf":
-        return ["sudo", "dnf", "install", "-y"] + names
-    if manager == "yum":
-        return ["sudo", "yum", "install", "-y"] + names
-    if manager == "pacman":
-        return ["sudo", "pacman", "-S", "--noconfirm", "--needed"] + names
-    if manager == "zypper":
-        return ["sudo", "zypper", "--non-interactive", "install"] + names
-    if manager == "brew":
-        # Homebrew explicitly refuses to run under sudo.
-        return ["brew", "install"] + names
-    return None
-
-
 def install_multimodal_system_packages() -> int:
     """Ensure OS packages needed for multimodal document parsing are installed.
 
@@ -268,16 +172,21 @@ def install_multimodal_system_packages() -> int:
     package manager is detected, a warning is printed and the function returns
     non-zero without raising so the rest of init can continue.
     """
-    canonical_pkgs = list(_MULTIMODAL_OS_PACKAGES.keys())
-    manager, dist_id = _detect_pkg_manager()
+    from rapidfireai.utils.os_utils import (
+        MULTIMODAL_OS_PACKAGES,
+        build_install_cmd,
+        check_multimodal_os_packages,
+    )
+
+    result = check_multimodal_os_packages()
+    manager = result["manager"]
     if manager is None:
         print("⚠️ Could not detect a supported OS package manager for multimodal dependencies.")
         print("   Please install the following packages manually using sudo or the equivalent")
-        print(f"   for your operating system: {', '.join(canonical_pkgs)}")
+        print(f"   for your operating system: {', '.join(MULTIMODAL_OS_PACKAGES.keys())}")
         return 1
 
-    native_names = [_MULTIMODAL_OS_PACKAGES[p].get(manager, p) for p in canonical_pkgs]
-    missing = [n for n in native_names if not _is_os_pkg_installed(manager, n)]
+    missing = result["missing"]
     if not missing:
         print(f"✅ All multimodal system dependencies already installed (via {manager})")
         return 0
@@ -291,7 +200,7 @@ def install_multimodal_system_packages() -> int:
         except FileNotFoundError:
             pass
 
-    cmd = _build_install_cmd(manager, missing)
+    cmd = build_install_cmd(manager, missing)
     if cmd is None:
         print(f"⚠️ No install command available for package manager '{manager}'.")
         print(f"   Please install these packages manually: {', '.join(missing)}")

--- a/rapidfireai/utils/doctor.py
+++ b/rapidfireai/utils/doctor.py
@@ -8,6 +8,10 @@ from pathlib import Path
 from rapidfireai.utils.python_info import get_python_info, get_pip_packages
 from rapidfireai.utils.gpu_info import get_gpu_info, get_torch_version
 from rapidfireai.utils.ping import ping_server
+from rapidfireai.utils.os_utils import (
+    check_multimodal_os_packages,
+    check_multimodal_python_packages,
+)
 from rapidfireai.utils.constants import (
     JupyterConfig,
     DispatcherConfig,
@@ -164,6 +168,48 @@ def get_doctor_info(log_lines: int = 10):
     else:
         status = 1 if status == 0 else status
         print("⚠️ Torch CUDA Version: unknown")
+
+    # Multimodal document parsing dependencies (rapidfireai init --evals --multimodal)
+    print("\n🧰 Multimodal Document Parsing Dependencies:")
+    print("-" * 30)
+    os_check = check_multimodal_os_packages()
+    if os_check["manager"] is None:
+        status = 1 if status == 0 else status
+        print("⚠️ Could not detect a supported OS package manager; cannot verify OS packages.")
+        print(f"   Distro detected: {os_check['distro_id'] or 'unknown'}")
+        print("   Expected packages (Debian/Ubuntu names): "
+              + ", ".join(p["canonical"] for p in os_check["packages"]))
+    else:
+        print(f"OS Package Manager: {os_check['manager']} (distro: {os_check['distro_id'] or 'unknown'})")
+        any_missing = False
+        for pkg in os_check["packages"]:
+            if pkg["installed"]:
+                marker = "✅"
+            else:
+                marker = "❌"
+                any_missing = True
+            label = pkg["canonical"]
+            if pkg["native"] != pkg["canonical"]:
+                label = f"{pkg['canonical']} ({pkg['native']})"
+            print(f"  {marker} {label}")
+        if any_missing:
+            status = 1 if status == 0 else status
+            print("⚠️ Missing OS packages above are needed for multimodal document parsing.")
+            print("   Reinstall with: rapidfireai init --evals --multimodal")
+
+    py_check = check_multimodal_python_packages()
+    print("Multimodal Python packages:")
+    any_py_missing = False
+    for pkg in py_check["packages"]:
+        if pkg["installed"]:
+            print(f"  ✅ {pkg['name']} {pkg['version']}")
+        else:
+            print(f"  ❌ {pkg['name']} (not installed)")
+            any_py_missing = True
+    if any_py_missing:
+        status = 1 if status == 0 else status
+        print("⚠️ Missing Python packages above are needed for multimodal document parsing.")
+        print("   Reinstall with: rapidfireai init --evals --multimodal")
 
     # Check RapidFire AI ports
     print ("\n🛜 RapidFire AI Ports:")

--- a/rapidfireai/utils/doctor.py
+++ b/rapidfireai/utils/doctor.py
@@ -169,47 +169,50 @@ def get_doctor_info(log_lines: int = 10):
         status = 1 if status == 0 else status
         print("⚠️ Torch CUDA Version: unknown")
 
-    # Multimodal document parsing dependencies (rapidfireai init --evals --multimodal)
-    print("\n🧰 Multimodal Document Parsing Dependencies:")
-    print("-" * 30)
-    os_check = check_multimodal_os_packages()
-    if os_check["manager"] is None:
-        status = 1 if status == 0 else status
-        print("⚠️ Could not detect a supported OS package manager; cannot verify OS packages.")
-        print(f"   Distro detected: {os_check['distro_id'] or 'unknown'}")
-        print("   Expected packages (Debian/Ubuntu names): "
-              + ", ".join(p["canonical"] for p in os_check["packages"]))
-    else:
-        print(f"OS Package Manager: {os_check['manager']} (distro: {os_check['distro_id'] or 'unknown'})")
-        any_missing = False
-        for pkg in os_check["packages"]:
-            if pkg["installed"]:
-                marker = "✅"
-            else:
-                marker = "❌"
-                any_missing = True
-            label = pkg["canonical"]
-            if pkg["native"] != pkg["canonical"]:
-                label = f"{pkg['canonical']} ({pkg['native']})"
-            print(f"  {marker} {label}")
-        if any_missing:
+    # Multimodal document parsing dependencies (rapidfireai init --evals --multimodal).
+    # Only relevant in evals mode; skip entirely in fit mode so unrelated warnings
+    # don't appear when multimodal features aren't expected to be available.
+    if mode == "evals":
+        print("\n🧰 Multimodal Document Parsing Dependencies:")
+        print("-" * 30)
+        os_check = check_multimodal_os_packages()
+        if os_check["manager"] is None:
             status = 1 if status == 0 else status
-            print("⚠️ Missing OS packages above are needed for multimodal document parsing.")
-            print("   Reinstall with: rapidfireai init --evals --multimodal")
-
-    py_check = check_multimodal_python_packages()
-    print("Multimodal Python packages:")
-    any_py_missing = False
-    for pkg in py_check["packages"]:
-        if pkg["installed"]:
-            print(f"  ✅ {pkg['name']} {pkg['version']}")
+            print("⚠️ Could not detect a supported OS package manager; cannot verify OS packages.")
+            print(f"   Distro detected: {os_check['distro_id'] or 'unknown'}")
+            print("   Expected packages (Debian/Ubuntu names): "
+                  + ", ".join(p["canonical"] for p in os_check["packages"]))
         else:
-            print(f"  ❌ {pkg['name']} (not installed)")
-            any_py_missing = True
-    if any_py_missing:
-        status = 1 if status == 0 else status
-        print("⚠️ Missing Python packages above are needed for multimodal document parsing.")
-        print("   Reinstall with: rapidfireai init --evals --multimodal")
+            print(f"OS Package Manager: {os_check['manager']} (distro: {os_check['distro_id'] or 'unknown'})")
+            any_missing = False
+            for pkg in os_check["packages"]:
+                if pkg["installed"]:
+                    marker = "✅"
+                else:
+                    marker = "❌"
+                    any_missing = True
+                label = pkg["canonical"]
+                if pkg["native"] != pkg["canonical"]:
+                    label = f"{pkg['canonical']} ({pkg['native']})"
+                print(f"  {marker} {label}")
+            if any_missing:
+                status = 1 if status == 0 else status
+                print("⚠️ Missing OS packages above are needed for multimodal document parsing.")
+                print("   Reinstall with: rapidfireai init --evals --multimodal")
+
+        py_check = check_multimodal_python_packages()
+        print("Multimodal Python packages:")
+        any_py_missing = False
+        for pkg in py_check["packages"]:
+            if pkg["installed"]:
+                print(f"  ✅ {pkg['name']} {pkg['version']}")
+            else:
+                print(f"  ❌ {pkg['name']} (not installed)")
+                any_py_missing = True
+        if any_py_missing:
+            status = 1 if status == 0 else status
+            print("⚠️ Missing Python packages above are needed for multimodal document parsing.")
+            print("   Reinstall with: rapidfireai init --evals --multimodal")
 
     # Check RapidFire AI ports
     print ("\n🛜 RapidFire AI Ports:")

--- a/rapidfireai/utils/os_utils.py
+++ b/rapidfireai/utils/os_utils.py
@@ -1,9 +1,200 @@
 """Utility functions for OS information."""
 
-import subprocess
+import platform
 import re
+import shutil
+import subprocess
 import os
 from pathlib import Path
+
+
+# Canonical (Debian/Ubuntu) OS package name -> per-package-manager native name.
+# Used to install / verify OS dependencies required by ``unstructured[all-docs]``
+# (PDF / OCR / XML toolchain) for the ``--multimodal`` init option.
+MULTIMODAL_OS_PACKAGES = {
+    "libmagic1":    {"apt": "libmagic1",    "dnf": "file-libs",     "yum": "file-libs",     "pacman": "file",     "zypper": "file-magic",   "brew": "libmagic"},
+    "poppler-utils":{"apt": "poppler-utils","dnf": "poppler-utils", "yum": "poppler-utils", "pacman": "poppler",  "zypper": "poppler-tools","brew": "poppler"},
+    "tesseract-ocr":{"apt": "tesseract-ocr","dnf": "tesseract",     "yum": "tesseract",     "pacman": "tesseract","zypper": "tesseract-ocr","brew": "tesseract"},
+    "libxml2":      {"apt": "libxml2",      "dnf": "libxml2",       "yum": "libxml2",       "pacman": "libxml2",  "zypper": "libxml2-2",    "brew": "libxml2"},
+    "libxslt1-dev": {"apt": "libxslt1-dev", "dnf": "libxslt-devel", "yum": "libxslt-devel", "pacman": "libxslt",  "zypper": "libxslt-devel","brew": "libxslt"},
+    "wget":         {"apt": "wget",         "dnf": "wget",          "yum": "wget",          "pacman": "wget",     "zypper": "wget",         "brew": "wget"},
+    "unrar":        {"apt": "unrar",        "dnf": "unrar",         "yum": "unrar",         "pacman": "unrar",    "zypper": "unrar",        "brew": "unrar"},
+}
+
+# Python packages that pair with the multimodal OS packages above.
+MULTIMODAL_PYTHON_PACKAGES = ["unstructured", "nltk"]
+
+
+def detect_pkg_manager():
+    """Detect the OS package manager.
+
+    Returns (manager, distro_id). ``manager`` is one of
+    ``apt``/``dnf``/``yum``/``pacman``/``zypper``/``brew`` or ``None`` if
+    nothing supported is available.
+    """
+    system = platform.system()
+    if system == "Darwin":
+        return ("brew" if shutil.which("brew") else None, "macos")
+    if system != "Linux":
+        return (None, system.lower())
+
+    try:
+        import distro  # type: ignore
+        dist_id = (distro.id() or "").lower()
+    except Exception:
+        dist_id = ""
+
+    debian_like = {"debian", "ubuntu", "linuxmint", "pop", "kali", "raspbian", "elementary"}
+    rhel_like = {"rhel", "centos", "fedora", "rocky", "almalinux", "amzn", "ol"}
+    arch_like = {"arch", "manjaro", "endeavouros"}
+    suse_like = {"opensuse", "opensuse-leap", "opensuse-tumbleweed", "sles"}
+
+    if dist_id in debian_like and shutil.which("apt-get"):
+        return ("apt", dist_id)
+    if dist_id in rhel_like:
+        if shutil.which("dnf"):
+            return ("dnf", dist_id)
+        if shutil.which("yum"):
+            return ("yum", dist_id)
+    if dist_id in arch_like and shutil.which("pacman"):
+        return ("pacman", dist_id)
+    if dist_id in suse_like and shutil.which("zypper"):
+        return ("zypper", dist_id)
+
+    for mgr, cmd in (("apt", "apt-get"), ("dnf", "dnf"), ("yum", "yum"),
+                      ("pacman", "pacman"), ("zypper", "zypper")):
+        if shutil.which(cmd):
+            return (mgr, dist_id)
+
+    return (None, dist_id)
+
+
+def is_os_pkg_installed(manager: str, name: str) -> bool:
+    """Return True if an OS package is installed via the given package manager."""
+    try:
+        if manager == "apt":
+            r = subprocess.run(["dpkg", "-s", name], capture_output=True, text=True, check=False)
+            return r.returncode == 0 and "Status: install ok installed" in r.stdout
+        if manager in ("dnf", "yum", "zypper"):
+            r = subprocess.run(["rpm", "-q", name], capture_output=True, text=True, check=False)
+            return r.returncode == 0
+        if manager == "pacman":
+            r = subprocess.run(["pacman", "-Q", name], capture_output=True, text=True, check=False)
+            return r.returncode == 0
+        if manager == "brew":
+            r = subprocess.run(["brew", "list", "--formula", name], capture_output=True, text=True, check=False)
+            return r.returncode == 0
+    except FileNotFoundError:
+        return False
+    return False
+
+
+def build_install_cmd(manager: str, names: list[str]) -> list[str] | None:
+    """Build the install command for the given OS package manager."""
+    if manager == "apt":
+        return ["sudo", "apt-get", "install", "-y"] + names
+    if manager == "dnf":
+        return ["sudo", "dnf", "install", "-y"] + names
+    if manager == "yum":
+        return ["sudo", "yum", "install", "-y"] + names
+    if manager == "pacman":
+        return ["sudo", "pacman", "-S", "--noconfirm", "--needed"] + names
+    if manager == "zypper":
+        return ["sudo", "zypper", "--non-interactive", "install"] + names
+    if manager == "brew":
+        # Homebrew explicitly refuses to run under sudo.
+        return ["brew", "install"] + names
+    return None
+
+
+def check_multimodal_os_packages() -> dict:
+    """Check the multimodal OS dependencies.
+
+    Returns a dict::
+
+        {
+            "manager": str | None,
+            "distro_id": str,
+            "packages": [
+                {"canonical": str, "native": str, "installed": bool | None},
+                ...,
+            ],
+            "missing": [native names],
+            "all_installed": bool,
+        }
+
+    When no supported package manager is detected, ``manager`` is ``None``,
+    ``installed`` is ``None`` for each package, ``missing`` is the full list
+    of canonical names, and ``all_installed`` is ``False``.
+    """
+    manager, dist_id = detect_pkg_manager()
+    packages: list[dict] = []
+    missing: list[str] = []
+
+    if manager is None:
+        for canonical in MULTIMODAL_OS_PACKAGES:
+            packages.append({"canonical": canonical, "native": canonical, "installed": None})
+            missing.append(canonical)
+        return {
+            "manager": None,
+            "distro_id": dist_id,
+            "packages": packages,
+            "missing": missing,
+            "all_installed": False,
+        }
+
+    for canonical, native_map in MULTIMODAL_OS_PACKAGES.items():
+        native = native_map.get(manager, canonical)
+        installed = is_os_pkg_installed(manager, native)
+        packages.append({"canonical": canonical, "native": native, "installed": installed})
+        if not installed:
+            missing.append(native)
+
+    return {
+        "manager": manager,
+        "distro_id": dist_id,
+        "packages": packages,
+        "missing": missing,
+        "all_installed": len(missing) == 0,
+    }
+
+
+def get_python_package_version(name: str) -> str | None:
+    """Return the installed version of a Python distribution, or ``None`` if missing."""
+    try:
+        from importlib.metadata import PackageNotFoundError, version
+    except ImportError:
+        return None
+    try:
+        return version(name)
+    except PackageNotFoundError:
+        return None
+
+
+def check_multimodal_python_packages() -> dict:
+    """Check the multimodal Python packages (``unstructured`` and ``nltk``).
+
+    Returns::
+
+        {
+            "packages": [{"name": str, "version": str | None, "installed": bool}, ...],
+            "missing": [names],
+            "all_installed": bool,
+        }
+    """
+    packages: list[dict] = []
+    missing: list[str] = []
+    for name in MULTIMODAL_PYTHON_PACKAGES:
+        ver = get_python_package_version(name)
+        installed = ver is not None
+        packages.append({"name": name, "version": ver, "installed": installed})
+        if not installed:
+            missing.append(name)
+    return {
+        "packages": packages,
+        "missing": missing,
+        "all_installed": len(missing) == 0,
+    }
 
 def mkdir_p(path: str, parents: bool = True, exist_ok: bool = True, notify: bool = True):
     """Create a directory if it does not exist."""

--- a/setup/start.sh
+++ b/setup/start.sh
@@ -190,12 +190,18 @@ cleanup() {
         exit 0
     fi
 
-    # Stop Ray cluster if running (best-effort) so its child processes
-    # (raylet, plasma store, GCS, dashboard, workers) are reaped before we
-    # fall back to killing whoever is bound to RF_RAY_PORT.
-    if command -v ray &> /dev/null; then
-        ray stop --force >/dev/null 2>&1 || true
-    fi
+    # NOTE: We intentionally do NOT run `ray stop --force` or broad
+    # `pkill -f "raylet|plasma_store|gcs_server|ray::"` here. Those commands
+    # would terminate every Ray process owned by the current user on this
+    # host -- including Ray clusters or workers started outside RapidFire AI
+    # (e.g. another notebook, another project, or another user on a shared
+    # box). Ray is only ever started from inside the user's experiment
+    # process (`ray.init()` in `rapidfireai/experiment.py`, evals mode), and
+    # that same process is responsible for tearing it down via
+    # `Experiment.end_experiment()` -> `ray.shutdown()`. The only Ray-related
+    # cleanup that is safe to do from here is freeing the RapidFire-
+    # configured Ray dashboard port (RF_RAY_PORT), which the port-kill loop
+    # below handles.
 
     # Kill processes by port (more reliable for MLflow)
     for port in $RF_MLFLOW_PORT $RF_FRONTEND_PORT $RF_API_PORT $RF_JUPYTER_PORT $RF_RAY_PORT; do
@@ -240,11 +246,10 @@ cleanup() {
         # Stop Converge if it was running
         pkill -f "converge start" 2>/dev/null || true
         pkill -f "uvicorn.*main:app" 2>/dev/null || true
-        # Reap any Ray stragglers that ray stop / port-kill missed.
-        pkill -f "raylet" 2>/dev/null || true
-        pkill -f "plasma_store" 2>/dev/null || true
-        pkill -f "gcs_server" 2>/dev/null || true
-        pkill -f "ray::" 2>/dev/null || true
+        # Deliberately no broad `pkill -f "raylet|plasma_store|gcs_server|ray::"`
+        # here -- see the note in the Ray cleanup section above. Those patterns
+        # would reap Ray processes belonging to other projects or other users
+        # on the same machine, not just RapidFire's own experiment.
     fi
 
     print_success "All services stopped"

--- a/setup/start.sh
+++ b/setup/start.sh
@@ -190,8 +190,15 @@ cleanup() {
         exit 0
     fi
 
+    # Stop Ray cluster if running (best-effort) so its child processes
+    # (raylet, plasma store, GCS, dashboard, workers) are reaped before we
+    # fall back to killing whoever is bound to RF_RAY_PORT.
+    if command -v ray &> /dev/null; then
+        ray stop --force >/dev/null 2>&1 || true
+    fi
+
     # Kill processes by port (more reliable for MLflow)
-    for port in $RF_MLFLOW_PORT $RF_FRONTEND_PORT $RF_API_PORT $RF_JUPYTER_PORT; do
+    for port in $RF_MLFLOW_PORT $RF_FRONTEND_PORT $RF_API_PORT $RF_JUPYTER_PORT $RF_RAY_PORT; do
         local pids=$(lsof -ti :$port 2>/dev/null || true)
         if [[ -n "$pids" ]]; then
             print_status "Killing processes on port $port"
@@ -233,6 +240,11 @@ cleanup() {
         # Stop Converge if it was running
         pkill -f "converge start" 2>/dev/null || true
         pkill -f "uvicorn.*main:app" 2>/dev/null || true
+        # Reap any Ray stragglers that ray stop / port-kill missed.
+        pkill -f "raylet" 2>/dev/null || true
+        pkill -f "plasma_store" 2>/dev/null || true
+        pkill -f "gcs_server" 2>/dev/null || true
+        pkill -f "ray::" 2>/dev/null || true
     fi
 
     print_success "All services stopped"


### PR DESCRIPTION
## Changes
- Adds a `--multimodal` flag to `rapidfireai init --evals` to check if required OS packages are installed, and will then install the needed Python packages

### Additions
- Adds a `--multimodal` flag to `rapidfireai init --evals` to check if required OS packages are installed, and will then install the needed Python packages
### Fixes
- If ctrl-c or `rapidfireai stop` is run during an experiment an orphaned ray process can be left over.  It now is killed


<img width="1056" height="712" alt="image" src="https://github.com/user-attachments/assets/495c7d0b-a9be-406a-bef4-901ba1413bb5" />

<img width="996" height="356" alt="image" src="https://github.com/user-attachments/assets/50db57d9-b87a-4719-8667-0c21c06e8269" />

<img width="956" height="142" alt="image" src="https://github.com/user-attachments/assets/21ece686-d33d-458b-a0e7-d4e30c7b8e09" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new `rapidfireai init --evals --multimodal` path that installs OS packages via detected package managers (using `sudo`) and extra Python deps, which can fail or behave differently across distros. Also tweaks shutdown/cleanup behavior by killing the Ray dashboard port, which could impact running processes bound to that port.
> 
> **Overview**
> Adds an opt-in `--multimodal` flag to `rapidfireai init` (only valid with `--evals`) that installs multimodal document-parsing dependencies: it detects the host package manager, checks/installs required OS packages (e.g. `poppler-utils`, `tesseract-ocr`) and installs `unstructured[all-docs]` + `nltk` via `uv pip`.
> 
> Extends `rapidfireai doctor` (evals mode only) to report multimodal OS/Python dependency status, and updates `start.sh` cleanup to also free the configured Ray dashboard port (`RF_RAY_PORT`) while explicitly avoiding broad Ray process termination.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee274a23d4d13ec38b2704fe4aeddc0efd8c7a30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->