### PR TITLE
Colab numpy pin to 2.0.1

### DIFF
--- a/rapidfireai/cli.py
+++ b/rapidfireai/cli.py
@@ -14,6 +14,7 @@ import subprocess
 import sys
 from pathlib import Path
 from importlib.resources import files
+from rapidfireai.utils import colab
 from rapidfireai.utils.get_ip_address import get_ip_address
 from rapidfireai.utils.python_info import get_python_info
 from rapidfireai.utils.constants import DispatcherConfig, JupyterConfig, ColabConfig, MLflowConfig
@@ -478,6 +479,10 @@ def install_packages(
             # packages.append({"package": "https://github.com/RapidFireAI/faiss-wheels/releases/download/v1.13.0/rf_faiss_gpu_12_8-1.13.0-cp39-abi3-manylinux_2_34_x86_64.whl", "extra_args": []})
 
         packages.append({"package": "numpy<2.3", "extra_args": ["--upgrade"]})
+    
+    if ColabConfig.ON_COLAB:
+        packages.append({"package": "cupy-cuda12x==14.0.1", "extra_args": ["--upgrade"]})
+        packages.append({"package": "numpy==2.0.1", "extra_args": ["--upgrade"]})
 
     for package_info in packages:
         try:

--- a/rapidfireai/cli.py
+++ b/rapidfireai/cli.py
@@ -14,7 +14,6 @@ import subprocess
 import sys
 from pathlib import Path
 from importlib.resources import files
-from rapidfireai.utils import colab
 from rapidfireai.utils.get_ip_address import get_ip_address
 from rapidfireai.utils.python_info import get_python_info
 from rapidfireai.utils.constants import DispatcherConfig, JupyterConfig, ColabConfig, MLflowConfig

--- a/rapidfireai/cli.py
+++ b/rapidfireai/cli.py
@@ -20,7 +20,6 @@ from rapidfireai.utils.constants import DispatcherConfig, JupyterConfig, ColabCo
 from rapidfireai.utils.doctor import get_doctor_info
 from rapidfireai.utils.constants import RF_EXPERIMENT_PATH, RF_HOME
 from rapidfireai.utils.gpu_info import get_compute_capability
-
 from .version import __version__
 
 RF_CONVERGE_MODE = os.getenv("RF_CONVERGE_MODE", "all")

--- a/setup/fit/requirements-colab.txt
+++ b/setup/fit/requirements-colab.txt
@@ -4,7 +4,7 @@ pandas>=2.0.0,<2.3.0  # Colab compatibility (2.2.2) and cudf constraint
 psutil>=5.9.0
 torch>=2.8.0
 transformers>=4.55.2
-peft>=0.17.0
+peft>=0.17.0,<0.19.0
 trl==0.21.0
 bitsandbytes>=0.47.0
 nltk>=3.9.1

--- a/setup/fit/requirements-local.txt
+++ b/setup/fit/requirements-local.txt
@@ -55,7 +55,7 @@ tensorboard>=2.11.0
 psutil==7.0.0
 tqdm==4.67.1
 typing-extensions>=4.0.0
-peft>=0.17.0
+peft>=0.17.0,<0.19.0
 trl==0.21.0
 bitsandbytes>=0.47.0
 nltk>=3.9.1


### PR DESCRIPTION
## Changes
- Fixes Google Colab notebooks upgrading numpy, by installing numpy 2.0.1
- Restricts peft<0.19.0 until transformers can be upgraded to >5.0

## Changelog Content

### Fixes
- Fixes Google Colab notebooks upgrading numpy, by installing numpy 2.0.1
- - Restricts peft<0.19.0 until transformers can be upgraded to >5.0



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency pinning that only affects installation behavior, primarily in Google Colab. Main risk is potential version conflicts if other deps expect newer `numpy`/`peft`.
> 
> **Overview**
> Prevents Google Colab installs from drifting by explicitly installing `numpy==2.0.1` (and `cupy-cuda12x==14.0.1`) during `rapidfireai init` package setup.
> 
> Pins `peft` to `>=0.17.0,<0.19.0` in both Colab and local `fit` requirements to avoid incompatibilities until `transformers` can be upgraded further.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a977c0e8257004bf8930d385799e796219eb79f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->