### PR TITLE
Bugfix - metrics display + clone step correction

### DIFF
--- a/rapidfireai/evals/scheduling/controller.py
+++ b/rapidfireai/evals/scheduling/controller.py
@@ -759,7 +759,7 @@ class Controller:
                     ray.kill(task["actor"])
                 except Exception as e:
                     self.logger.warning(
-                        f"Error killing DocProcessingActor for context "
+                        f"Could not kill DocProcessingActor for context "
                         f"{task['context_info'].get('context_id', '?')}: {e}"
                     )
 
@@ -774,7 +774,7 @@ class Controller:
                     ray.kill(rate_limiter)
                 except Exception as e:
                     self.logger.warning(
-                        f"Error killing build-phase rate limiter for provider '{provider}': {e}"
+                        f"Could not kill build-phase rate limiter for provider '{provider}': {e}"
                     )
 
             # Stop the context building display. Idempotent — the failure
@@ -884,7 +884,7 @@ class Controller:
 
                     self.logger.debug(f"Created Metrics run {metric_run_id} for pipeline {pipeline_id}")
                 except Exception as e:
-                    self.logger.warning(f"Failed to create Metrics run for pipeline {pipeline_id}: {e}")
+                    self.logger.warning(f"Could not create Metrics run for pipeline {pipeline_id}; continuing without metric tracking: {e}")
 
             pipeline_ids.append(pipeline_id)
             pipeline_id_to_config[pipeline_id] = pipeline_config
@@ -934,7 +934,7 @@ class Controller:
             # Skip DELETED and FAILED pipelines
             if pipeline_status in [PipelineStatus.DELETED.value, PipelineStatus.FAILED.value]:
                 if pipeline_status == PipelineStatus.FAILED.value:
-                    self.logger.warning(f"Pipeline {pipeline_id} failed, skipping final metrics")
+                    self.logger.warning(f"Skipping final metrics for pipeline {pipeline_id} (status: FAILED)")
                 else:
                     self.logger.info(f"Pipeline {pipeline_id} deleted, skipping final metrics")
                 continue
@@ -1063,14 +1063,14 @@ class Controller:
                                 try:
                                     self.metric_manager.log_metric(metric_run_id, metric_name, float(metric_value), step=step)
                                 except Exception as e:
-                                    self.logger.warning(f"Failed to log final metric {metric_name} to MetricLogger: {e}")
+                                    self.logger.warning(f"Could not log final metric {metric_name} to MetricLogger: {e}")
 
                             # Log confidence_interval if available
                             if confidence_interval is not None and isinstance(confidence_interval, (int, float)):
                                 try:
                                     self.metric_manager.log_metric(metric_run_id, f"{metric_name}_confidence_interval", float(confidence_interval), step=step)
                                 except Exception as e:
-                                    self.logger.warning(f"Failed to log final metric {metric_name}_confidence_interval to MetricLogger: {e}")
+                                    self.logger.warning(f"Could not log final metric {metric_name}_confidence_interval to MetricLogger: {e}")
 
                         try:
                             self.metric_manager.end_run(metric_run_id)
@@ -1588,14 +1588,14 @@ class Controller:
                                                 try:
                                                     self.metric_manager.log_metric(metric_run_id, metric_name, float(metric_value), step=step)
                                                 except Exception as e:
-                                                    self.logger.warning(f"Failed to log metric {metric_name} to MetricLogger: {e}")
+                                                    self.logger.warning(f"Could not log metric {metric_name} to MetricLogger: {e}")
 
                                             # Log confidence_interval if available
                                             if confidence_interval is not None and isinstance(confidence_interval, (int, float)):
                                                 try:
                                                     self.metric_manager.log_metric(metric_run_id, f"{metric_name}_confidence_interval", float(confidence_interval), step=step)
                                                 except Exception as e:
-                                                    self.logger.warning(f"Failed to log metric {metric_name}_confidence_interval to MetricLogger: {e}")
+                                                    self.logger.warning(f"Could not log metric {metric_name}_confidence_interval to MetricLogger: {e}")
 
                                         if "Throughput" in display_metrics:
                                             throughput_value = display_metrics["Throughput"]["value"]
@@ -1692,7 +1692,7 @@ class Controller:
                                         )
                             except Exception as e:
                                 self.logger.warning(
-                                    f"Optuna shard callback error for pipeline {pipeline_id}: {e}"
+                                    f"Optuna shard callback issue for pipeline {pipeline_id}: {e}"
                                 )
 
                         # Mark for cleanup
@@ -1969,7 +1969,7 @@ class Controller:
                 shard_callback.finalize(final_cb_metrics)
                 self.logger.info("Optuna shard callback finalized")
             except Exception as e:
-                self.logger.warning(f"Optuna shard callback finalize error: {e}")
+                self.logger.warning(f"Optuna shard callback finalize issue: {e}")
 
         # PHASE 8: Compute final metrics for each pipeline (including dynamically cloned ones).
         # pipeline_id_to_config contains all pipelines (originals + clones added via _handle_clone).

--- a/rapidfireai/evals/scheduling/controller.py
+++ b/rapidfireai/evals/scheduling/controller.py
@@ -1063,14 +1063,14 @@ class Controller:
                                 try:
                                     self.metric_manager.log_metric(metric_run_id, metric_name, float(metric_value), step=step)
                                 except Exception as e:
-                                    self.logger.debug(f"Failed to log final metric {metric_name} to MetricLogger: {e}")
+                                    self.logger.warning(f"Failed to log final metric {metric_name} to MetricLogger: {e}")
 
                             # Log confidence_interval if available
                             if confidence_interval is not None and isinstance(confidence_interval, (int, float)):
                                 try:
                                     self.metric_manager.log_metric(metric_run_id, f"{metric_name}_confidence_interval", float(confidence_interval), step=step)
                                 except Exception as e:
-                                    self.logger.debug(f"Failed to log final metric {metric_name}_confidence_interval to MetricLogger: {e}")
+                                    self.logger.warning(f"Failed to log final metric {metric_name}_confidence_interval to MetricLogger: {e}")
 
                         try:
                             self.metric_manager.end_run(metric_run_id)
@@ -1588,14 +1588,14 @@ class Controller:
                                                 try:
                                                     self.metric_manager.log_metric(metric_run_id, metric_name, float(metric_value), step=step)
                                                 except Exception as e:
-                                                    self.logger.debug(f"Failed to log metric {metric_name} to MetricLogger: {e}")
+                                                    self.logger.warning(f"Failed to log metric {metric_name} to MetricLogger: {e}")
 
                                             # Log confidence_interval if available
                                             if confidence_interval is not None and isinstance(confidence_interval, (int, float)):
                                                 try:
                                                     self.metric_manager.log_metric(metric_run_id, f"{metric_name}_confidence_interval", float(confidence_interval), step=step)
                                                 except Exception as e:
-                                                    self.logger.debug(f"Failed to log metric {metric_name}_confidence_interval to MetricLogger: {e}")
+                                                    self.logger.warning(f"Failed to log metric {metric_name}_confidence_interval to MetricLogger: {e}")
 
                                         if "Throughput" in display_metrics:
                                             throughput_value = display_metrics["Throughput"]["value"]

--- a/rapidfireai/fit/ml/trainer.py
+++ b/rapidfireai/fit/ml/trainer.py
@@ -1,3 +1,4 @@
+import copy
 import math
 import os
 import warnings
@@ -471,6 +472,14 @@ def _configure_training_args(
     training_args: dict, trainer_config: TrainerConfig, use_fsdp: bool = False
 ) -> dict:
     """Configure training arguments with default values."""
+    # Work on a deep copy so we don't mutate the caller's dict.
+    # The caller passes config_leaf["training_args"] by reference; mutating it
+    # (e.g. replacing user-set max_steps with num_train_epochs=1 below) would
+    # leak into the run's persisted config_leaf in the DB, and any subsequent
+    # clone / warm-clone would inherit those derived chunk-level values
+    # instead of the user's original config (see Cloned runs picking up
+    # num_train_epochs=1 instead of parent's max_steps).
+    training_args = copy.deepcopy(training_args)
     completed_steps = trainer_config.completed_steps
     if completed_steps > 0:
         training_args.pop("warmup_ratio", None)

--- a/rapidfireai/utils/metric_mlflow_manager.py
+++ b/rapidfireai/utils/metric_mlflow_manager.py
@@ -1,6 +1,7 @@
 """This module contains the MLflowManager class which is responsible for managing the MLflow runs."""
 
 import os
+import re
 import mlflow
 from mlflow.tracking import MlflowClient
 from typing import Any
@@ -8,6 +9,30 @@ from rapidfireai.utils.metric_logger import MetricLogger, MetricLoggerType
 from rapidfireai.utils.ping import ping_server
 from rapidfireai.utils.constants import MLflowConfig
 from rapidfireai.evals.utils.logger import RFLogger
+
+
+# MLflow only allows alphanumerics, underscores (_), dashes (-), periods (.),
+# colons (:), slashes (/), and spaces in metric and param names. Common
+# RAG/IR-style metric names such as ``NDCG@5`` or ``Recall@10`` therefore fail
+# MLflow validation and never reach the dashboard. We replace ``@`` with
+# ``_at_`` to preserve the human-readable intent (``NDCG@5`` -> ``NDCG_at_5``)
+# and fall back to ``_`` for any other disallowed character.
+_MLFLOW_NAME_INVALID_RE = re.compile(r"[^\w./\- :]")
+
+
+def _sanitize_mlflow_name(name: str) -> str:
+    """Convert a metric/param name into one MLflow accepts.
+
+    ``@`` is mapped to ``_at_`` so the meaning of names like ``NDCG@5`` is
+    preserved (``NDCG_at_5``); any other character outside MLflow's allowed
+    set is replaced with ``_``.
+    """
+    if not isinstance(name, str):
+        return name
+    # Map ``@`` first to preserve semantic meaning, then catch any other
+    # disallowed characters with a generic underscore replacement.
+    sanitized = name.replace("@", "_at_")
+    return _MLFLOW_NAME_INVALID_RE.sub("_", sanitized)
 
 
 class MLflowMetricLogger(MetricLogger):
@@ -54,11 +79,13 @@ class MLflowMetricLogger(MetricLogger):
 
     def log_param(self, run_id: str, key: str, value: str) -> None:
         """Log parameters to a specific run."""
-        self.client.log_param(run_id, key, value)
+        safe_key = _sanitize_mlflow_name(key)
+        self.client.log_param(run_id, safe_key, value)
 
     def log_metric(self, run_id: str, key: str, value: float, step: int = None) -> None:
         """Log a metric to a specific run."""
-        self.client.log_metric(run_id, key, value, step=step)
+        safe_key = _sanitize_mlflow_name(key)
+        self.client.log_metric(run_id, safe_key, value, step=step)
 
     def get_run_metrics(self, run_id: str) -> dict[str, list[tuple[int, float]]]:
         """


### PR DESCRIPTION
## Changes
1. Fix clones / warm-clones inheriting `num_train_epochs=1` instead of the parent's `max_steps` (or other user-set training args).

- Root cause: `_configure_training_args` mutated `config_leaf["training_args"]` in place (removing `max_steps`, setting chunk-level `num_train_epochs`/`max_steps`, adding `save_strategy="no"`, etc.). The worker then persisted that mutated `config_leaf` back to the DB, so the IC Ops UI showed — and clones inherited — the derived chunk-level values, not the user's original config.
- Fix: deep-copy `training_args` at the start of `_configure_training_args` so the run's persisted `config_leaf` keeps the user's original training args.

2. Fix: NDCG / @k metrics missing from MLflow dashboard
- Cause: MLflow rejects metric names containing @ (only allows [/\w.\- :]), so NDCG@5, Recall@10, etc. failed validation. The exception was swallowed at logger.debug in controller.py, so metrics rendered in the notebook table but never reached the MLflow charts.
- Fix: Added _sanitize_mlflow_name in MLflowMetricLogger.log_metric / log_param — maps @ → _at_ (so NDCG@5 → NDCG_at_5, keeping it readable) and replaces any other disallowed character with _. Sanitization is scoped to the MLflow backend; TensorBoard / Trackio still receive the original name.

## Testing
1. Ran `rf-tutorial-sft-chatqa-lite.ipynb` with `max_steps=128` on parent runs.
- start IC Ops on a parent — `training_args.max_steps` should still be `128` for the clones (previously gone, replaced by `num_train_epochs: 1`).
- Clone and Warm Clone the parent without edits — new run's `total_steps` should be `128`, matching the parent (previously  1 epoch).
2. Tested RAG FIQA Notebook and was able to observe NDCG metrics in mlflow dashboard.



## Screenshots (if applicable)
<img width="1470" height="956" alt="Screenshot 2026-05-27 at 10 03 25 AM" src="https://github.com/user-attachments/assets/d86b6ba6-c426-4a49-a00b-826e8f2abc20" />
<img width="1470" height="956" alt="Screenshot 2026-05-27 at 10 03 45 AM" src="https://github.com/user-attachments/assets/df55d7b3-6072-436c-8cea-6c530aa1a807" />
<img width="1470" height="956" alt="Screenshot 2026-05-27 at 10 04 08 AM" src="https://github.com/user-attachments/assets/e79ec075-58d0-4c1d-91de-31752bb0affc" />


## Related Issues
#253
#254 
