### PR TITLE
Bugfixes in optuna

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -239,6 +239,7 @@ commands.sh
 node_modules/
 package-lock.json
 rapidfireai/rapidfire_pids.txt
+converge_pids.txt
 
 # frontend build
 rapidfireai/frontend/build/

--- a/rapidfireai/automl/optuna_search.py
+++ b/rapidfireai/automl/optuna_search.py
@@ -209,6 +209,45 @@ def _extract_search_space(
 _PRIMITIVE_TYPES = (type(None), bool, int, float, str)
 
 
+def _attrs_for_labeling(obj: Any) -> dict[str, Any] | None:
+    """Return a primitive-only attribute dict describing *obj* for label building.
+
+    Returns ``None`` when *obj* has no labellable structure (e.g. ``None``,
+    a list/tuple, or a built-in type without a ``__dict__``) -- the caller
+    falls back to ``repr(obj)`` for those.
+
+    - ``dict``                       -> shallow copy of primitive entries
+    - object with ``__dict__``       -> ``vars(obj)`` filtered to primitives
+    - everything else                -> ``None``
+    """
+    if obj is None:
+        return None
+    if isinstance(obj, dict):
+        src: dict[Any, Any] = obj
+    elif isinstance(obj, (list, tuple, set, frozenset)):
+        return None
+    else:
+        src = getattr(obj, "__dict__", None)
+        if not src:
+            return None
+    attrs: dict[str, Any] = {}
+    for key, val in src.items():
+        if isinstance(val, _PRIMITIVE_TYPES):
+            attrs[str(key).lstrip("_")] = val
+        elif isinstance(val, type):
+            attrs[str(key).lstrip("_")] = val.__name__
+    return attrs
+
+
+def _label_prefix(obj: Any) -> str:
+    """Return the class-name-like prefix used when building a label for *obj*."""
+    if obj is None:
+        return "None"
+    if isinstance(obj, dict):
+        return "cfg"
+    return type(obj).__name__
+
+
 def _object_labels(objects: list[Any]) -> list[str]:
     """Build concise labels showing only the attributes that differ across *objects*.
 
@@ -220,30 +259,38 @@ def _object_labels(objects: list[Any]) -> list[str]:
 
     Shared defaults (``keep_separator``, ``strip_whitespace``, etc.) are omitted
     so the labels stay short and meaningful in Optuna trial output.
+
+    A single ``List([...])`` may freely mix:
+
+    - regular objects (labelled by class name + differing attrs)
+    - plain ``dict`` configs (labelled ``cfg(...)``)
+    - ``list`` / ``tuple`` literals (labelled via ``repr``)
+    - ``None`` (labelled ``"None"``, e.g. an optional reranker)
     """
-    per_obj: list[tuple[str, dict[str, Any]]] = []
-    for obj in objects:
-        attrs = {}
-        for key, val in sorted(vars(obj).items()):
-            if isinstance(val, _PRIMITIVE_TYPES):
-                attrs[key.lstrip("_")] = val
-        per_obj.append((type(obj).__name__, attrs))
+    per_obj: list[tuple[str, dict[str, Any] | None]] = [
+        (_label_prefix(obj), _attrs_for_labeling(obj)) for obj in objects
+    ]
 
     all_keys: set[str] = set()
     for _, attrs in per_obj:
-        all_keys.update(attrs)
+        if attrs:
+            all_keys.update(attrs)
 
     varying = {
         k for k in all_keys
-        if len({attrs.get(k) for _, attrs in per_obj}) > 1
+        if len({(attrs or {}).get(k) for _, attrs in per_obj}) > 1
     }
     if not varying:
         varying = all_keys
 
     labels: list[str] = []
-    for cls_name, attrs in per_obj:
+    for i, (prefix, attrs) in enumerate(per_obj):
+        obj = objects[i]
+        if attrs is None:
+            labels.append("None" if obj is None else repr(obj))
+            continue
         parts = [f"{k}={attrs[k]!r}" for k in sorted(varying) if k in attrs]
-        labels.append(f"{cls_name}({', '.join(parts)})" if parts else repr(objects[len(labels)]))
+        labels.append(f"{prefix}({', '.join(parts)})" if parts else prefix)
     return labels
 
 
@@ -271,10 +318,11 @@ def _suggest_value(trial: optuna.Trial, name: str, param: Range | List) -> Any:
     elif isinstance(param, List):
         if all(isinstance(v, _PRIMITIVE_TYPES) for v in param.values):
             return trial.suggest_categorical(name, param.values)
-        if all(isinstance(v, (list, tuple, dict)) for v in param.values):
-            labels = [repr(v) for v in param.values]
-        else:
-            labels = _object_labels(param.values)
+        # Mixed primitive / dict / object choices (including ``None`` for an
+        # optional component such as a reranker) -- always go through
+        # ``_object_labels``, which handles every type uniformly and never calls
+        # ``vars()`` on a value that lacks ``__dict__``.
+        labels = _object_labels(param.values)
         if len(set(labels)) < len(labels):
             labels = [f"{lbl}#{i}" for i, lbl in enumerate(labels)]
         chosen = trial.suggest_categorical(name, labels)
@@ -428,12 +476,30 @@ def _template_to_leaf_fit(config_obj: Any, trainer_type: str) -> dict[str, Any]:
     return leaf
 
 
+_PIPELINE_KEY_ALIASES = (
+    "pipeline",
+    "vllm_config",
+    "api_config",
+    "openai_config",
+    "gemini_config",
+)
+
+
 def _template_to_leaf_evals(config_dict: dict[str, Any]) -> dict[str, Any]:
-    """Convert a sampled evals config dict into a config-leaf dict for the controller."""
+    """Convert a sampled evals config dict into a config-leaf dict for the controller.
+
+    Mirrors :func:`grid_search._get_runs_evals` /
+    :func:`random_search._get_runs_evals` by recognising any of the historical
+    pipeline keys (``pipeline``, ``vllm_config``, ``api_config``,
+    ``openai_config``, ``gemini_config``) and normalising the result to a
+    single ``"pipeline"`` key -- the controller looks up ``config_leaf["pipeline"]``
+    unconditionally, so omitting an alias here used to crash sharded evals
+    runs that built their config with ``api_config=...``.
+    """
     from rapidfireai.automl.random_search import recursive_expand_randomsearch
 
     pipeline_key = None
-    for key in ("pipeline", "vllm_config", "openai_config", "gemini_config"):
+    for key in _PIPELINE_KEY_ALIASES:
         if key in config_dict:
             pipeline_key = key
             break
@@ -447,8 +513,7 @@ def _template_to_leaf_evals(config_dict: dict[str, Any]) -> dict[str, Any]:
     additional = {
         k: recursive_expand_randomsearch(v)
         for k, v in config_dict.items()
-        if k not in {"pipeline", "vllm_config", "openai_config", "gemini_config"}
-        and v is not None
+        if k not in _PIPELINE_KEY_ALIASES and v is not None
     }
 
     return {"pipeline": pipeline_instance, **additional}

--- a/rapidfireai/evals/actors/query_actor.py
+++ b/rapidfireai/evals/actors/query_actor.py
@@ -135,32 +135,29 @@ class QueryProcessingActor:
 
             config_hash = hashlib.md5(config_str.encode()).hexdigest()
 
+            # Two situations can leave a stale ``current_engine_config_hash``
+            # paired with a missing or torn-down ``inference_engine``:
+            #
+            #  1) A prior ``initialize_for_pipeline`` raised after the cleanup
+            #     branch ran but before ``inference_engine`` was re-created.
+            #  2) External ``cleanup()`` released the engine without resetting
+            #     the hash.
+            #
+            # If the next pipeline happens to share the same engine config (true
+            # for every API-only experiment that uses a single shared generator,
+            # such as SciFact's Gemini setup under ``num_shards > 1``), the
+            # ``hash matches`` short-circuit below would otherwise reuse a
+            # nonexistent engine and ``process_batch`` would AttributeError.
+            # Normalising to a clean ``None`` state up-front forces a rebuild.
+            if getattr(self, "inference_engine", None) is None:
+                self.current_engine_config_hash = None
+
             # Only reinitialize if the engine config has changed
             if self.current_engine_config_hash != config_hash:
                 # Clean up old engine if it exists
                 if self.inference_engine is not None:
                     self.logger.info(f"Cleaning up old inference engine (hash: {self.current_engine_config_hash[:8]})")
-                    try:
-                        self.inference_engine.cleanup()
-                    except Exception as e:
-                        self.logger.warning(f"Error during engine cleanup: {e}")
-
-                    # Force garbage collection and GPU memory release
-                    del self.inference_engine
-                    import gc
-
-                    gc.collect()
-
-                    # For CUDA, explicitly empty cache
-                    try:
-                        import torch
-
-                        if torch.cuda.is_available():
-                            torch.cuda.empty_cache()
-                            torch.cuda.synchronize()
-                            self.logger.info("GPU memory cache cleared")
-                    except ImportError:
-                        pass
+                    self._teardown_inference_engine()
 
                 self.logger.info(f"Initializing new inference engine (config hash: {config_hash[:8]})")
                 self.inference_engine = engine_class(**engine_kwargs)
@@ -436,9 +433,45 @@ class QueryProcessingActor:
                 f"Error processing batch: {error_type}: {error_message}"
             ) from None  # Don't chain to avoid serialization issues
 
+    def _teardown_inference_engine(self) -> None:
+        """Release the current inference engine, clear bookkeeping, and free GPU memory.
+
+        Always leaves ``self.inference_engine`` set to ``None`` (never deleted)
+        and ``self.current_engine_config_hash`` cleared, so that any subsequent
+        ``initialize_for_pipeline`` -- including one that re-uses the previous
+        engine's config hash -- correctly rebuilds the engine instead of
+        short-circuiting onto a freed handle.
+        """
+        if self.inference_engine is None:
+            self.current_engine_config_hash = None
+            return
+        try:
+            self.inference_engine.cleanup()
+        except Exception as e:
+            self.logger.warning(f"Error during engine cleanup: {e}")
+        # Assigning ``None`` (rather than ``del``) keeps the attribute defined
+        # so later ``is not None`` checks remain valid even if a fresh engine
+        # never gets created (e.g. exception during ``engine_class(...)``).
+        self.inference_engine = None
+        self.current_engine_config_hash = None
+
+        import gc
+        gc.collect()
+        try:
+            import torch
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+                torch.cuda.synchronize()
+                self.logger.info("GPU memory cache cleared")
+        except ImportError:
+            pass
+
     def cleanup(self):
-        """Clean up inference engine resources."""
-        self.inference_engine.cleanup()
+        """Clean up inference engine resources.
+
+        Safe to call multiple times and when no engine is currently loaded.
+        """
+        self._teardown_inference_engine()
 
 
 # Export for external use

--- a/rapidfireai/evals/scheduling/controller.py
+++ b/rapidfireai/evals/scheduling/controller.py
@@ -1671,6 +1671,26 @@ class Controller:
                                                 "start_time": None,
                                             }
                                             scheduler.add_pipeline(new_pid, shards_completed=0)
+
+                                            # Replacement pipelines must inherit the
+                                            # parent's API resources. The rate limiter
+                                            # actor + max-completion-tokens maps are only
+                                            # populated for the initial wave of pipelines
+                                            # at experiment setup; without copying the
+                                            # parent's (``pipeline_id``) entries here the
+                                            # worker would build an ``APIInferenceEngine``
+                                            # with no ``rate_limiter_actor`` and fail to
+                                            # initialize (only manifests under sharding,
+                                            # where pruning + relaunch actually happens).
+                                            if pipeline_id in pipeline_to_rate_limiter:
+                                                pipeline_to_rate_limiter[new_pid] = (
+                                                    pipeline_to_rate_limiter[pipeline_id]
+                                                )
+                                            if pipeline_id in pipeline_to_max_completion_tokens:
+                                                pipeline_to_max_completion_tokens[new_pid] = (
+                                                    pipeline_to_max_completion_tokens[pipeline_id]
+                                                )
+
                                             if hasattr(shard_callback, "_remap_pending_trial"):
                                                 shard_callback._remap_pending_trial(new_pid)
 

--- a/tests/test_optuna.py
+++ b/tests/test_optuna.py
@@ -13,6 +13,7 @@ from rapidfireai.automl.optuna_search import (
     OptunaShardCallback,
     RFOptuna,
     _extract_search_space,
+    _object_labels,
     _resolve_metric_history,
     _resolve_scalar_for_objective,
     _sample_from_trial,
@@ -804,3 +805,108 @@ class TestMultiTemplate:
         assert replacement is not None
         assert isinstance(replacement, dict)
         assert cb._spawned == 3
+
+
+# ---------------------------------------------------------------------------
+# Categorical-choice labelling and evals-leaf pipeline-key normalisation
+# (regression tests for issues found while running RFOptuna on RAG configs
+# whose List(...) categoricals mixed dicts, None, and lists, or whose evals
+# template used ``api_config`` instead of ``vllm_config``/``pipeline``).
+# ---------------------------------------------------------------------------
+
+
+class TestObjectLabels:
+    def test_dict_only_choices(self):
+        labels = _object_labels(
+            [{"type": "similarity", "k": k} for k in (5, 10, 20)]
+        )
+        assert labels == ["cfg(k=5)", "cfg(k=10)", "cfg(k=20)"]
+
+    def test_none_plus_dict_choices(self):
+        labels = _object_labels([None, {"class": str, "top_n": 5}])
+        assert labels[0] == "None"
+        assert labels[1].startswith("cfg(")
+        assert "top_n=5" in labels[1]
+
+    def test_list_of_lists_choices(self):
+        choices = [["q_proj", "v_proj"], ["q_proj", "k_proj", "v_proj", "o_proj"]]
+        labels = _object_labels(choices)
+        assert labels == [repr(c) for c in choices]
+
+    def test_object_choices_with_dict(self):
+        class Splitter:
+            def __init__(self, chunk_size, overlap):
+                self.chunk_size = chunk_size
+                self._overlap = overlap
+
+        labels = _object_labels([Splitter(256, 32), Splitter(512, 32)])
+        assert labels == ["Splitter(chunk_size=256)", "Splitter(chunk_size=512)"]
+
+    def test_mixed_obj_dict_none_list(self):
+        class TS:
+            def __init__(self, chunk_size):
+                self.chunk_size = chunk_size
+
+        labels = _object_labels([TS(128), {"k": 10}, None, ["a", "b"]])
+        assert labels[0].startswith("TS(")
+        assert labels[1].startswith("cfg(")
+        assert labels[2] == "None"
+        assert labels[3] == "['a', 'b']"
+
+    def test_suggest_value_mixed_none_dict_does_not_crash(self):
+        study = optuna.create_study(direction="maximize")
+        trial = study.ask()
+        choices = [None, {"class": str, "top_n": 5}]
+        sampled = _suggest_value(trial, "reranker_cfg", List(choices))
+        assert sampled in choices
+
+    def test_suggest_value_dict_choices(self):
+        study = optuna.create_study(direction="maximize")
+        trial = study.ask()
+        choices = [{"type": "similarity", "k": k} for k in (5, 10, 20)]
+        sampled = _suggest_value(trial, "search_cfg", List(choices))
+        assert sampled in choices
+
+
+class TestTemplateToLeafEvalsPipelineAliases:
+    """``_template_to_leaf_evals`` must normalise every supported pipeline alias
+    to a ``"pipeline"`` key, matching grid_search/random_search and the
+    controller's ``config_leaf["pipeline"]`` lookup."""
+
+    def test_pipeline_alias_passthrough(self):
+        leaf = _template_to_leaf_evals({"pipeline": "p", "batch_size": 4})
+        assert leaf["pipeline"] == "p"
+        assert leaf["batch_size"] == 4
+
+    def test_vllm_alias_renamed(self):
+        leaf = _template_to_leaf_evals({"vllm_config": "v", "x": 1})
+        assert leaf["pipeline"] == "v"
+        assert "vllm_config" not in leaf
+        assert leaf["x"] == 1
+
+    def test_api_alias_renamed(self):
+        """Regression: api_config was silently dropped, leaving the leaf
+        without a ``pipeline`` key and crashing the controller downstream."""
+        sentinel = object()
+        leaf = _template_to_leaf_evals(
+            {"api_config": sentinel, "batch_size": 32, "preprocess_fn": "fn"}
+        )
+        assert leaf["pipeline"] is sentinel
+        assert "api_config" not in leaf
+        assert leaf["batch_size"] == 32
+        assert leaf["preprocess_fn"] == "fn"
+
+    def test_gemini_alias_renamed(self):
+        leaf = _template_to_leaf_evals({"gemini_config": "g"})
+        assert leaf["pipeline"] == "g"
+        assert "gemini_config" not in leaf
+
+    def test_openai_alias_renamed(self):
+        leaf = _template_to_leaf_evals({"openai_config": "o"})
+        assert leaf["pipeline"] == "o"
+        assert "openai_config" not in leaf
+
+    def test_unknown_keys_returned_unchanged(self):
+        original = {"foo": 1, "bar": 2}
+        leaf = _template_to_leaf_evals(original)
+        assert leaf == original


### PR DESCRIPTION
### Changes
- Fixes four bugs that prevented end-to-end sharded (`num_shards > 1`) `RFOptuna` RAG eval runs. See [#268](https://github.com/RapidFireAI/rapidfireai/issues/268).
- No breaking changes. Only the replacement-pipeline path in `controller.py` is newly modified; the other three were already addressed.

### Changelog Content
#### Additions
- None.
#### Changes
- None.
#### Fixes
- Optuna label building no longer crashes on `dict`/`None` categorical knob choices (#268).
- Optuna leaf configs now carry the `pipeline` key so the controller can launch them (#268).
- Query actor reuses its inference engine only when it actually exists, fixing `AttributeError` under sharding (#268).
- Replacement (relaunched) pipelines now inherit the parent's rate limiter and max-completion-tokens, fixing inference-engine init failures (#268).

### Testing
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change manually
- [ ] I have tested this change in the following environments:
  - [x] Local development
  - [ ] Docker environment
  - [x] Other: 4×L4 (24GB) box, `num_shards` ∈ {1, 4, 8}
  
  
### Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

### Performance Impact
No performance impact. Replacements reuse the existing shared per-provider rate-limiter actor rather than creating new ones.

### Related Issues
#268 