### PR TITLE
Updated default to evals

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ pip uninstall -y hf-xet
 
 # For Fine-tuning/Post-Training: Install specific dependencies and initialize rapidfireai
 
-rapidfireai init
+rapidfireai init --train
 rapidfireai start
 
 # It should print about 50 lines, including the following:
@@ -97,7 +97,7 @@ ssh -L 8853:localhost:8853 username@remote-machine
 
 
 # For RAG/Context Engineering Evals: Install specific dependencies and initialize rapidfireai
-rapidfireai init --evals
+rapidfireai init
 rapidfireai start
 
 # It should print about 50 lines, including the following:

--- a/community_notebooks/rag-fiqa-context-optimization.ipynb
+++ b/community_notebooks/rag-fiqa-context-optimization.ipynb
@@ -132,10 +132,10 @@
     "    print(\"✅ rapidfireai already installed\")\n",
     "except ImportError:\n",
     "    %pip install rapidfireai==0.14.0  # Takes 1 min\n",
-    "    !rapidfireai init --evals # Takes 1 min\n",
+    "    !rapidfireai init # Takes 1 min\n",
     "\n",
     "# Re-download tutorial datasets\n",
-    "!rapidfireai init --evals"
+    "!rapidfireai init"
    ]
   },
   {

--- a/community_notebooks/rag-nfcorpus-biomedical-qa.ipynb
+++ b/community_notebooks/rag-nfcorpus-biomedical-qa.ipynb
@@ -99,7 +99,7 @@
     "    print(\"✅ rapidfireai already installed\")\n",
     "except ImportError:\n",
     "    !pip install rapidfireai==0.14.0  # Takes 1 min\n",
-    "    !rapidfireai init --evals # Takes 1 min"
+    "    !rapidfireai init # Takes 1 min"
    ]
   },
   {

--- a/community_notebooks/rag-qasper-scientific-paper-qa.ipynb
+++ b/community_notebooks/rag-qasper-scientific-paper-qa.ipynb
@@ -130,7 +130,7 @@
         "    print(f\"✓ RapidFire {rapidfireai.__version__} already installed.\")\n",
         "except ImportError:\n",
         "    %pip install rapidfireai==0.14.0  # Takes 1 min\n",
-        "    !rapidfireai init --evals # Takes 1 min\n",
+        "    !rapidfireai init # Takes 1 min\n",
         "    print(\"⚠️  PLEASE RESTART RUNTIME NOW (Runtime > Restart Session) to load new versions.\")\n",
         "\n",
         "# --- 2. Global Imports & Configuration ---\n",

--- a/community_notebooks/rag-ucsb-course-catalog.ipynb
+++ b/community_notebooks/rag-ucsb-course-catalog.ipynb
@@ -120,7 +120,7 @@
         "    print(\"✅ rapidfireai already installed\")\n",
         "except ImportError:\n",
         "    %pip install rapidfireai==0.14.0\n",
-        "    !rapidfireai init --evals"
+        "    !rapidfireai init"
       ],
       "metadata": {
         "id": "2uUDsBt62kGw"

--- a/community_notebooks/sft-child-facing-chatbot.ipynb
+++ b/community_notebooks/sft-child-facing-chatbot.ipynb
@@ -86,7 +86,7 @@
     "For the full RapidFire AI experience—advanced experiment management, UI, and production features—we recommend installing the package on a machine you control (for example, a VM or your local machine) rather than Google Colab. See our [Install and Get Started](https://oss-docs.rapidfire.ai/en/latest/walkthrough.html) guide.\n",
     "\n",
     "### Option 2: Install in Google Colab\n",
-    "For simplicity, you can run this notebook on Google Colab. The cell below installs `rapidfireai` if not already present, then runs `rapidfireai init` to set up the environment."
+    "For simplicity, you can run this notebook on Google Colab. The cell below installs `rapidfireai` if not already present, then runs `rapidfireai init --train` to set up the environment."
    ]
   },
   {
@@ -106,7 +106,7 @@
     "    print(\"✅ rapidfireai already installed\")\n",
     "except ImportError:\n",
     "    %pip install rapidfireai==0.14.0\n",
-    "    !rapidfireai init"
+    "    !rapidfireai init --train"
    ]
   },
   {

--- a/community_notebooks/sft-cybersecurity-qa.ipynb
+++ b/community_notebooks/sft-cybersecurity-qa.ipynb
@@ -90,7 +90,7 @@
     "except ImportError:\n",
     "    %pip install rapidfireai==0.14.0  # Takes 1 min\n",
     "    %pip install bert_score\n",
-    "    !rapidfireai init # Takes 1 min"
+    "    !rapidfireai init --train # Takes 1 min"
    ]
   },
   {

--- a/community_notebooks/sft-ecommerce-retail-chatbot.ipynb
+++ b/community_notebooks/sft-ecommerce-retail-chatbot.ipynb
@@ -38,7 +38,7 @@
       "metadata": {
         "id": "-WRkVXAx1iTM"
       },
-      "source": "## Install RapidFire AI Package and Setup\n\n### Option 1: Install Locally (or on a VM)\nFor the full RapidFire AI experience—advanced experiment management, UI, and production features—we recommend installing the package on a machine you control (for example, a VM or your local machine) rather than Google Colab. See our [Install and Get Started](https://oss-docs.rapidfire.ai/en/latest/walkthrough.html) guide.\n\n### Option 2: Install in Google Colab\nFor simplicity, you can run this notebook on Google Colab. The cell below installs `rapidfireai` and evaluation dependencies (`evaluate`, `sacrebleu`) if they are not already present, then runs `rapidfireai init` to set up the environment."
+      "source": "## Install RapidFire AI Package and Setup\n\n### Option 1: Install Locally (or on a VM)\nFor the full RapidFire AI experience—advanced experiment management, UI, and production features—we recommend installing the package on a machine you control (for example, a VM or your local machine) rather than Google Colab. See our [Install and Get Started](https://oss-docs.rapidfire.ai/en/latest/walkthrough.html) guide.\n\n### Option 2: Install in Google Colab\nFor simplicity, you can run this notebook on Google Colab. The cell below installs `rapidfireai` and evaluation dependencies (`evaluate`, `sacrebleu`) if they are not already present, then runs `rapidfireai init --train` to set up the environment."
     },
     {
       "cell_type": "code",
@@ -54,7 +54,7 @@
         "if importlib.util.find_spec(\"evaluate\") is None:\n",
         "    pip_install([\"evaluate\", \"sacrebleu\"])\n",
         "\n",
-        "!rapidfireai init"
+        "!rapidfireai init --train"
       ],
       "outputs": [],
       "execution_count": null

--- a/community_notebooks/sft-pii-masking-redaction.ipynb
+++ b/community_notebooks/sft-pii-masking-redaction.ipynb
@@ -88,7 +88,7 @@
     "    print(\"✅ rapidfireai and mlflow already installed\")\n",
     "except ImportError:\n",
     "    %pip install rapidfireai==0.14.0 mlflow  # Install both rapidfireai and mlflow\n",
-    "    !rapidfireai init # Takes 1 min"
+    "    !rapidfireai init --train # Takes 1 min"
    ]
   },
   {

--- a/rapidfireai/cli.py
+++ b/rapidfireai/cli.py
@@ -281,12 +281,12 @@ def install_packages(
         and evals
     ):
         print(
-            " ⚠️ Could not detect CUDA (nvcc and nvidia-smi unavailable or failed).\n"
+            "    Did not detect CUDA (nvcc and nvidia-smi unavailable).\n"
             "    Disabling CUDA usage for evaluation dependencies.\n"
             "    If you want to override this explicitly pass the CUDA version, for example:\n"
-            "        rapidfireai init --evals --cudaversion 12.4\n"
+            "        rapidfireai init --cudaversion 12.4\n"
             "    If nvidia-smi is unavailable, also pass --computecapabilityversion (see --help).\n"
-            "          If there is no GPU available, you can ignore this warning.",
+            "          If there is no GPU available, you can ignore this.",
             file=sys.stderr,
         )
         compute_capability_version = "0.0"
@@ -302,12 +302,12 @@ def install_packages(
         compute_cap = get_compute_capability()
         if compute_cap is None:
             print(
-                "⚠️ Could not detect GPU compute capability (nvidia-smi unavailable or failed).\n"
+                "   Did not detect GPU compute capability (nvidia-smi unavailable).\n"
                 "   Disabling CUDA usage for evaluation dependencies.\n"
                 "   Pass it explicitly, for example:\n"
-                "   rapidfireai init --evals --computecapabilityversion 8.0\n"
+                "   rapidfireai init --computecapabilityversion 8.0\n"
                 "   (Use your GPU's SM version, e.g. 8.9 for Ada, 9.0 for Blackwell.)\n"
-                "          If there is no GPU available, you can ignore this warning.",
+                "          If there is no GPU available, you can ignore this.",
                 file=sys.stderr,
             )
             compute_cap = 0.0
@@ -682,17 +682,17 @@ def main():
     parser = argparse.ArgumentParser(description="RapidFire AI - Start/stop/manage services", prog="rapidfireai",
     epilog="""
 Examples:
-  # Basic initialization for training
+  # Basic initialization with evaluation dependencies (default)
   rapidfireai init
-  #or
-  # Basic Initialize with evaluation dependencies
-  rapidfireai init --evals
+
+  # Initialize with training-only dependencies (skips evaluation dependencies)
+  rapidfireai init --train
 
   # Initialize with evaluation + multimodal document parsing dependencies
-  rapidfireai init --evals --multimodal
+  rapidfireai init --multimodal
 
   # Init when nvcc/nvidia-smi are unavailable (pin CUDA / compute capability)
-  rapidfireai init --evals --cudaversion 12.4 --computecapabilityversion 8.0
+  rapidfireai init --cudaversion 12.4 --computecapabilityversion 8.0
   
   # Start services
   rapidfireai start
@@ -750,7 +750,17 @@ For more information, visit: https://github.com/RapidFireAI/rapidfireai
 
     parser.add_argument("--force", "-f", action="store_true", help="Force action without confirmation")
 
-    parser.add_argument("--evals", action="store_true", help="Initialize with evaluation dependencies")
+    parser.add_argument(
+        "--evals",
+        action="store_true",
+        help="Initialize with evaluation dependencies (this is now the default)",
+    )
+
+    parser.add_argument(
+        "--train",
+        action="store_true",
+        help="Initialize with training-only dependencies (skips evaluation dependencies)",
+    )
 
     parser.add_argument(
         "--multimodal",
@@ -821,8 +831,11 @@ For more information, visit: https://github.com/RapidFireAI/rapidfireai
 
     # Handle init command separately
     if args.command == "init":
+        # Evaluation dependencies are installed by default; --train opts into a
+        # training-only install. --evals is kept for backwards compatibility.
+        evals = not args.train
         return run_init(
-            args.evals,
+            evals,
             multimodal=args.multimodal,
             cuda_version=args.cuda_version,
             compute_capability_version=args.compute_capability_version,

--- a/tests/notebooks/rag-contexteng/[Colab_Pro]rf_blitzkrieg.ipynb
+++ b/tests/notebooks/rag-contexteng/[Colab_Pro]rf_blitzkrieg.ipynb
@@ -42,7 +42,7 @@
         "    print(\"✅ rapidfireai already installed\")\n",
         "except ImportError:\n",
         "    %pip install \"rapidfireai @ git+https://github.com/RapidFireAI/rapidfireai.git@feature/api-gateway\"\n",
-        "    !rapidfireai init --evals # Takes 1 min"
+        "    !rapidfireai init # Takes 1 min"
       ]
     },
     {

--- a/tests/notebooks/rag-contexteng/rf-multimodal-cloudstorage.ipynb
+++ b/tests/notebooks/rag-contexteng/rf-multimodal-cloudstorage.ipynb
@@ -41,7 +41,7 @@
         "Make sure to install the system dependencies using:\n",
         "\n",
         "```bash\n",
-        "rapidfireai init --evals --multimodal\n",
+        "rapidfireai init --multimodal\n",
         "```\n",
         "\n",
         "Followed by:\n",

--- a/tests/notebooks/rag-contexteng/rf-multimodal-local.ipynb
+++ b/tests/notebooks/rag-contexteng/rf-multimodal-local.ipynb
@@ -41,7 +41,7 @@
         "Make sure to install the system dependencies using:\n",
         "\n",
         "```bash\n",
-        "rapidfireai init --evals --multimodal\n",
+        "rapidfireai init --multimodal\n",
         "```\n",
         "\n",
         "Followed by:\n",

--- a/tests/staging/tutorial_notebooks/fine-tuning/rf-colab-tensorboard-tutorial.ipynb
+++ b/tests/staging/tutorial_notebooks/fine-tuning/rf-colab-tensorboard-tutorial.ipynb
@@ -59,7 +59,7 @@
         "    print(\"✅ rapidfireai already installed\")\n",
         "except ImportError:\n",
         "    %pip install rapidfireai==0.16.0 # Takes 1 min\n",
-        "    !rapidfireai init # Takes 1 min"
+        "    !rapidfireai init --train # Takes 1 min"
       ]
     },
     {

--- a/tests/staging/tutorial_notebooks/fine-tuning/trackio/rf-colab-tutorial-sft-trackio.ipynb
+++ b/tests/staging/tutorial_notebooks/fine-tuning/trackio/rf-colab-tutorial-sft-trackio.ipynb
@@ -59,7 +59,7 @@
         "    print(\"✅ rapidfireai already installed\")\n",
         "except ImportError:\n",
         "    %pip install rapidfireai==0.16.0 # Takes 1 min\n",
-        "    !rapidfireai init # Takes 1 min"
+        "    !rapidfireai init --train # Takes 1 min"
       ]
     },
     {

--- a/tests/staging/tutorial_notebooks/rag-contexteng/rf-colab-rag-fiqa-tutorial.ipynb
+++ b/tests/staging/tutorial_notebooks/rag-contexteng/rf-colab-rag-fiqa-tutorial.ipynb
@@ -107,7 +107,7 @@
         "    print(\"✅ rapidfireai already installed\")\n",
         "except ImportError:\n",
         "    %pip install rapidfireai==0.16.0 # Takes 1 min\n",
-        "!rapidfireai init --evals # Takes 1 min"
+        "!rapidfireai init # Takes 1 min"
       ]
     },
     {

--- a/tests/staging/tutorial_notebooks/rag-contexteng/trackio/rf-colab-tutorial-rag-fiqa-trackio.ipynb
+++ b/tests/staging/tutorial_notebooks/rag-contexteng/trackio/rf-colab-tutorial-rag-fiqa-trackio.ipynb
@@ -111,7 +111,7 @@
     "    print(\"✅ rapidfireai already installed\")\n",
     "except ImportError:\n",
     "    %pip install rapidfireai==0.16.0 # Takes 1 min\n",
-    "    !rapidfireai init --evals # Takes 1 min"
+    "    !rapidfireai init # Takes 1 min"
    ]
   },
   {

--- a/tutorial_notebooks/fine-tuning/rf-colab-tensorboard-tutorial.ipynb
+++ b/tutorial_notebooks/fine-tuning/rf-colab-tensorboard-tutorial.ipynb
@@ -59,7 +59,7 @@
         "    print(\"✅ rapidfireai already installed\")\n",
         "except ImportError:\n",
         "    %pip install rapidfireai==0.16.0 # Takes 1 min\n",
-        "    !rapidfireai init # Takes 1 min"
+        "    !rapidfireai init --train # Takes 1 min"
       ]
     },
     {

--- a/tutorial_notebooks/fine-tuning/trackio/rf-colab-tutorial-sft-trackio.ipynb
+++ b/tutorial_notebooks/fine-tuning/trackio/rf-colab-tutorial-sft-trackio.ipynb
@@ -59,7 +59,7 @@
         "    print(\"✅ rapidfireai already installed\")\n",
         "except ImportError:\n",
         "    %pip install rapidfireai==0.16.0 # Takes 1 min\n",
-        "    !rapidfireai init # Takes 1 min"
+        "    !rapidfireai init --train # Takes 1 min"
       ]
     },
     {

--- a/tutorial_notebooks/rag-contexteng/rf-colab-rag-fiqa-tutorial.ipynb
+++ b/tutorial_notebooks/rag-contexteng/rf-colab-rag-fiqa-tutorial.ipynb
@@ -107,7 +107,7 @@
         "    print(\"✅ rapidfireai already installed\")\n",
         "except ImportError:\n",
         "    %pip install rapidfireai==0.16.0 # Takes 1 min\n",
-        "!rapidfireai init --evals # Takes 1 min"
+        "!rapidfireai init # Takes 1 min"
       ]
     },
     {

--- a/tutorial_notebooks/rag-contexteng/rf-tutorial-MMDocIR.ipynb
+++ b/tutorial_notebooks/rag-contexteng/rf-tutorial-MMDocIR.ipynb
@@ -41,7 +41,7 @@
         "Make sure to install the system dependencies using:\n",
         "\n",
         "```bash\n",
-        "rapidfireai init --evals --multimodal\n",
+        "rapidfireai init --multimodal\n",
         "```\n",
         "\n",
         "Followed by:\n",

--- a/tutorial_notebooks/rag-contexteng/trackio/rf-colab-tutorial-rag-fiqa-trackio.ipynb
+++ b/tutorial_notebooks/rag-contexteng/trackio/rf-colab-tutorial-rag-fiqa-trackio.ipynb
@@ -111,7 +111,7 @@
     "    print(\"✅ rapidfireai already installed\")\n",
     "except ImportError:\n",
     "    %pip install rapidfireai==0.16.0 # Takes 1 min\n",
-    "    !rapidfireai init --evals # Takes 1 min"
+    "    !rapidfireai init # Takes 1 min"
    ]
   },
   {


### PR DESCRIPTION
## Changes
- Changed default behavior for `rapidfireai init` to be `--evals`, to do training use `rapidfireai init --train`

## Changelog Content
### Changes
- Changed default behavior for `rapidfireai init` to be `--evals`, to do training use `rapidfireai init --train`


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changing the default install profile can surprise existing users who relied on training-only `init`, though `--train` and legacy `--evals` limit breakage.
> 
> **Overview**
> **`rapidfireai init` now installs evaluation/RAG dependencies by default.** Training-only setup moves to **`rapidfireai init --train`**. **`--evals` remains** as a no-op alias for backward compatibility; **`evals = not args.train`** drives `run_init`.
> 
> CLI **help and epilog examples** are updated (plain `init` for evals, `--train` for fine-tuning, **`--multimodal`** without requiring `--evals` in examples). **CUDA/compute-capability stderr hints** drop `--evals` from suggested commands and soften wording.
> 
> **README** and **community/tutorial/test notebooks** align: RAG notebooks use `rapidfireai init`; SFT notebooks use **`init --train`**; multimodal docs use **`init --multimodal`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 928deaad2ee66b0fbe2d350bbb6fc055a57a669b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->