### PR TITLE
Bugfix/dispatcher mlflow mismatch

### DIFF
--- a/rapidfireai/evals/actors/query_actor.py
+++ b/rapidfireai/evals/actors/query_actor.py
@@ -97,38 +97,17 @@ class QueryProcessingActor:
 
         Here we only need to clear the *local* per-actor active-run stack
         so the subsequent ``mlflow.start_run(run_id=...)`` for the new
-        pipeline can succeed. The work mirrors ``mlflow.end_run`` minus the
-        ``set_terminated`` call.
+        pipeline can succeed. Delegates to the shared
+        :func:`rapidfireai.utils.metric_mlflow_manager.clear_local_mlflow_active_run_stack`
+        helper so this code path stays in sync with the ``create_experiment``
+        / ``end_experiment`` / ``clear_context`` fallbacks that use the
+        same trick to avoid the FINISHED-clobber bug.
         """
-        try:
-            from mlflow.tracking import fluent
-            from mlflow.environment_variables import MLFLOW_RUN_ID
+        from rapidfireai.utils.metric_mlflow_manager import (
+            clear_local_mlflow_active_run_stack,
+        )
 
-            active_stack = fluent._active_run_stack.get()
-            if active_stack:
-                MLFLOW_RUN_ID.unset()
-                run = active_stack.pop()
-                fluent._last_active_run_id.set(run.info.run_id)
-                # Tear down the per-run system-metrics monitor if mlflow
-                # started one; otherwise it would leak.
-                monitor = fluent.run_id_to_system_metrics_monitor.pop(
-                    run.info.run_id, None
-                )
-                if monitor is not None:
-                    try:
-                        monitor.finish()
-                    except Exception:
-                        pass
-        except Exception as e:
-            # Fluent-API internals can shift between MLflow versions. If
-            # the private symbols ever change, fall back to no-op: the next
-            # mlflow.start_run() will raise a clearer error than we could
-            # synthesize here, and we'd rather surface that than risk
-            # accidentally marking the previous run as FINISHED.
-            self.logger.warning(
-                f"Could not clear local MLflow active-run stack for run "
-                f"{self.metric_run_id}: {e}"
-            )
+        clear_local_mlflow_active_run_stack(self.logger)
 
     def initialize_for_pipeline(
         self,

--- a/rapidfireai/evals/actors/query_actor.py
+++ b/rapidfireai/evals/actors/query_actor.py
@@ -85,6 +85,51 @@ class QueryProcessingActor:
         self.current_engine_config_hash = None  # Track currently loaded model
         self.metric_run_id = None  # MLflow run ID for trace association
 
+    def _clear_local_mlflow_active_run(self) -> None:
+        """Pop this actor's MLflow active-run stack WITHOUT terminating on the server.
+
+        ``mlflow.end_run()`` fires ``SetTerminated(FINISHED)`` on the server,
+        which would mark a pipeline as COMPLETED on the dashboard even though
+        the pipeline may still have shards in flight on other actors (or
+        scheduled for this actor's later requests). The controller owns the
+        terminal-state decision and calls ``metric_manager.end_run(..., status=...)``
+        when the pipeline is truly done / failed / stopped.
+
+        Here we only need to clear the *local* per-actor active-run stack
+        so the subsequent ``mlflow.start_run(run_id=...)`` for the new
+        pipeline can succeed. The work mirrors ``mlflow.end_run`` minus the
+        ``set_terminated`` call.
+        """
+        try:
+            from mlflow.tracking import fluent
+            from mlflow.environment_variables import MLFLOW_RUN_ID
+
+            active_stack = fluent._active_run_stack.get()
+            if active_stack:
+                MLFLOW_RUN_ID.unset()
+                run = active_stack.pop()
+                fluent._last_active_run_id.set(run.info.run_id)
+                # Tear down the per-run system-metrics monitor if mlflow
+                # started one; otherwise it would leak.
+                monitor = fluent.run_id_to_system_metrics_monitor.pop(
+                    run.info.run_id, None
+                )
+                if monitor is not None:
+                    try:
+                        monitor.finish()
+                    except Exception:
+                        pass
+        except Exception as e:
+            # Fluent-API internals can shift between MLflow versions. If
+            # the private symbols ever change, fall back to no-op: the next
+            # mlflow.start_run() will raise a clearer error than we could
+            # synthesize here, and we'd rather surface that than risk
+            # accidentally marking the previous run as FINISHED.
+            self.logger.warning(
+                f"Could not clear local MLflow active-run stack for run "
+                f"{self.metric_run_id}: {e}"
+            )
+
     def initialize_for_pipeline(
         self,
         engine_class: type[InferenceEngine],
@@ -305,19 +350,50 @@ class QueryProcessingActor:
                 self.prompt_manager.pipeline_id = pipeline_id
                 self.prompt_manager.model_name = model_name
 
-            # End any previously active MLflow run on this actor (happens when reused for a second pipeline).
-            # This marks the previous run as FINISHED on the server, but that's fine:
-            # the controller uses MlflowClient (not the fluent API) for final metric logging,
-            # which works on terminated runs, and its own end_run() is idempotent.
-            if self.metric_run_id and is_mlflow_enabled():
-                mlflow.end_run()
+            # Handle the actor's MLflow active-run context across pipeline
+            # transitions. Three cases:
+            #
+            # 1. Same pipeline, next shard (metric_run_id unchanged): leave
+            #    everything alone -- the active run is already open on this
+            #    actor and stays open until the controller (which is the
+            #    single authority on pipeline completion) explicitly ends it.
+            #
+            # 2. Switching to a different pipeline while the previous one is
+            #    still RUNNING on the server: we MUST NOT call
+            #    mlflow.end_run(), because that fires SetTerminated(FINISHED)
+            #    on the server and the previous pipeline may still have
+            #    shards in flight on other actors -- the dashboard would
+            #    flicker COMPLETED while the notebook still shows ONGOING.
+            #    Instead, clear only this actor's local active-run stack so
+            #    mlflow.start_run() below can take the new run, and leave
+            #    the server status untouched. The controller is responsible
+            #    for setting the terminal status when (and only when) the
+            #    pipeline has truly finished, failed, or been stopped.
+            #
+            # 3. Switching to a different pipeline whose previous run is
+            #    already terminal on the server (KILLED / FAILED / FINISHED
+            #    -- e.g. user IC-stop or controller-side error handler ran
+            #    while this actor was busy): the server state is correct;
+            #    we just need to clear local context and move on.
+            same_pipeline_next_shard = (
+                self.metric_run_id is not None and self.metric_run_id == metric_run_id
+            )
+            if self.metric_run_id and is_mlflow_enabled() and not same_pipeline_next_shard:
+                self._clear_local_mlflow_active_run()
 
             # Set the active MLflow run so traces are associated with this pipeline's run.
             # metric_run_id is a real MLflow UUID only when MLflow is enabled; when disabled
             # RFMetricLogger falls back to a plain run-name string which mlflow.start_run()
             # cannot accept, so the call must also be gated on is_mlflow_enabled().
+            # When this is the same pipeline continuing across shards, the active
+            # MLflow run is already open on this actor; calling start_run again
+            # would raise "Run with UUID ... is already active" -- skip in that case.
             self.metric_run_id = metric_run_id
-            if self.metric_run_id and is_mlflow_enabled():
+            if (
+                self.metric_run_id
+                and is_mlflow_enabled()
+                and not same_pipeline_next_shard
+            ):
                 mlflow.start_run(run_id=self.metric_run_id)
 
         except Exception as e:

--- a/rapidfireai/evals/scheduling/controller.py
+++ b/rapidfireai/evals/scheduling/controller.py
@@ -119,6 +119,30 @@ class Controller:
 
         return sanitized
 
+    def _finalize_mlflow_run(self, db: RFDatabase, pipeline_id: int, mlflow_status: str) -> None:
+        """Terminate the MLflow run for ``pipeline_id`` with the given MLflow status.
+
+        Best-effort: MLflow failures are logged but never propagated. ``mlflow_status``
+        must be one of MLflow's ``RunStatus`` strings (``"FINISHED"``, ``"FAILED"``,
+        ``"KILLED"``). See :data:`DISPATCHER_TO_MLFLOW_STATUS` in
+        ``metric_mlflow_manager`` for the dispatcher -> MLflow mapping used here.
+        """
+        if not self.metric_manager:
+            return
+        try:
+            pipeline = db.get_pipeline(pipeline_id)
+            metric_run_id = pipeline.get("metric_run_id") if pipeline else None
+            if not metric_run_id:
+                return
+            self.metric_manager.end_run(metric_run_id, status=mlflow_status)
+            self.logger.info(
+                f"Marked MLflow run {metric_run_id} as {mlflow_status} for pipeline {pipeline_id}"
+            )
+        except Exception as e:
+            self.logger.warning(
+                f"Failed to terminate MLflow run for pipeline {pipeline_id} (status={mlflow_status}): {e}"
+            )
+
     def _log_pipeline_params(
         self,
         pipeline_config: dict,
@@ -1073,7 +1097,10 @@ class Controller:
                                     self.logger.warning(f"Could not log final metric {metric_name}_confidence_interval to MetricLogger: {e}")
 
                         try:
-                            self.metric_manager.end_run(metric_run_id)
+                            # COMPLETED dispatcher status -> MLflow FINISHED.
+                            # Explicit for clarity; matches the dispatcher ->
+                            # MLflow mapping in metric_mlflow_manager.
+                            self.metric_manager.end_run(metric_run_id, status="FINISHED")
                         except Exception as e:
                             self.logger.debug(f"Failed to end MetricLogger run {metric_run_id}: {e}")
                 except Exception as e:
@@ -1239,6 +1266,45 @@ class Controller:
 
         # PHASE 5: Register pipelines in database
         pipeline_ids, pipeline_id_to_config = self._register_pipelines(config_leaves, db)
+
+        # Publish shard-progress totals to MLflow so the dashboard's Shards
+        # column can render "x/N". We use tags (not params) because the
+        # paired "current" value is mutable and tags are MLflow's only
+        # mutable per-run key/value primitive. The frontend reads both:
+        # rapidfire.progress.current / rapidfire.progress.total.
+        #
+        # We use the lightweight ``get_pipeline_by_id_lite`` path
+        # (``include_decoded_config=False``) to avoid dill-decoding large
+        # FAISS/embedder objects -- decoding here would add seconds per
+        # pipeline and risk SIGSEGVs (see the docstring on
+        # ``RFDatabase.get_pipeline``).
+        if self.metric_manager:
+            seeded = 0
+            for pipeline_id in pipeline_ids:
+                pipeline = db.get_pipeline(pipeline_id, include_decoded_config=False)
+                metric_run_id = pipeline.get("metric_run_id") if pipeline else None
+                if not metric_run_id:
+                    continue
+                try:
+                    self.metric_manager.set_tag(
+                        metric_run_id, "rapidfire.progress.total", str(num_shards)
+                    )
+                    self.metric_manager.set_tag(
+                        metric_run_id, "rapidfire.progress.current", "0"
+                    )
+                    seeded += 1
+                except Exception as e:
+                    # Promoted from debug to warning -- this used to silently
+                    # swallow failures, which made it hard to diagnose why
+                    # the Shards column rendered "-" on the dashboard.
+                    self.logger.warning(
+                        f"Could not set initial progress tags for pipeline "
+                        f"{pipeline_id} (run {metric_run_id}): {e}"
+                    )
+            self.logger.info(
+                f"Seeded rapidfire.progress tags on {seeded}/{len(pipeline_ids)} "
+                f"MLflow runs (total={num_shards})"
+            )
 
         # Bind Optuna trials to the newly created DB pipeline IDs
         if shard_callback is not None and hasattr(config_group, "bind_initial_trials"):
@@ -1505,6 +1571,32 @@ class Controller:
                         samples_processed = shards_completed * len(shards[0])  # Approximate
                         db.set_pipeline_progress(pipeline_id, shard_id + 1, shards_completed, samples_processed)
 
+                        # Mirror the dispatcher's shards_completed into an MLflow
+                        # tag so the dashboard's Shards column updates live.
+                        # Tag (not metric) because the frontend reads a single
+                        # current value, not a time series.
+                        # ``include_decoded_config=False`` keeps this off the
+                        # hot per-shard path (see seeding block above for the
+                        # same caveat).
+                        if self.metric_manager:
+                            try:
+                                pipeline_row = db.get_pipeline(
+                                    pipeline_id, include_decoded_config=False
+                                )
+                                metric_run_id = (
+                                    pipeline_row.get("metric_run_id") if pipeline_row else None
+                                )
+                                if metric_run_id:
+                                    self.metric_manager.set_tag(
+                                        metric_run_id,
+                                        "rapidfire.progress.current",
+                                        str(shards_completed),
+                                    )
+                            except Exception as e:
+                                self.logger.warning(
+                                    f"Could not update progress tag for pipeline {pipeline_id}: {e}"
+                                )
+
                         # Check if pipeline completed all shards
                         if shards_completed >= num_shards:
                             # Mark as completed (metrics will be finalized in Phase 8)
@@ -1636,6 +1728,10 @@ class Controller:
                                     db.set_pipeline_status(pipeline_id, PipelineStatus.STOPPED)
                                     progress_display.update_pipeline(pipeline_id, status="STOPPED")
                                     scheduler.remove_pipeline(pipeline_id)
+                                    # Optuna prune maps to MLflow KILLED -- same as
+                                    # user IC-stop. Both are intentional terminations
+                                    # rather than failures or clean finishes.
+                                    self._finalize_mlflow_run(db, pipeline_id, "KILLED")
                                     self.logger.info(
                                         f"Optuna pruned pipeline {pipeline_id} after shard {shard_id}"
                                     )
@@ -1655,6 +1751,40 @@ class Controller:
                                         new_ids, new_map = self._register_pipelines(
                                             [shard_decision.replacement_config], db
                                         )
+                                        # Seed shards-progress tags on the
+                                        # replacement runs too, mirroring the
+                                        # initial-registration path above.
+                                        # Without this the Shards column on
+                                        # the dashboard would read "-" for
+                                        # any Optuna-spawned replacement.
+                                        if self.metric_manager:
+                                            for new_pid in new_ids:
+                                                repl_row = db.get_pipeline(
+                                                    new_pid, include_decoded_config=False
+                                                )
+                                                repl_run = (
+                                                    repl_row.get("metric_run_id")
+                                                    if repl_row
+                                                    else None
+                                                )
+                                                if not repl_run:
+                                                    continue
+                                                try:
+                                                    self.metric_manager.set_tag(
+                                                        repl_run,
+                                                        "rapidfire.progress.total",
+                                                        str(num_shards),
+                                                    )
+                                                    self.metric_manager.set_tag(
+                                                        repl_run,
+                                                        "rapidfire.progress.current",
+                                                        "0",
+                                                    )
+                                                except Exception as e:
+                                                    self.logger.warning(
+                                                        f"Could not seed progress tags for "
+                                                        f"replacement pipeline {new_pid}: {e}"
+                                                    )
                                         for new_pid in new_ids:
                                             pipeline_id_to_config[new_pid] = new_map[new_pid]
                                             pipeline_ids.append(new_pid)
@@ -1728,6 +1858,10 @@ class Controller:
                         db.set_actor_task_error(task_id, error_msg)
                         db.set_pipeline_status(pipeline_id, PipelineStatus.FAILED)
                         db.set_pipeline_error(pipeline_id, error_msg)
+
+                        # Mirror the dispatcher FAILED state into MLflow so the
+                        # dashboard stops showing this run as RUNNING.
+                        self._finalize_mlflow_run(db, pipeline_id, "FAILED")
 
                         # Display error in notebook (but don't halt the experiment)
                         pipeline_config = pipeline_id_to_config.get(pipeline_id)
@@ -1946,6 +2080,7 @@ class Controller:
                 db.set_actor_task_error(task_id, error_msg)
                 db.set_pipeline_status(pipeline_id, PipelineStatus.FAILED)
                 db.set_pipeline_error(pipeline_id, error_msg)
+                self._finalize_mlflow_run(db, pipeline_id, "FAILED")
                 scheduler.remove_pipeline(pipeline_id)
                 if progress_display:
                     progress_display.update_pipeline(pipeline_id, status="FAILED")
@@ -1996,6 +2131,7 @@ class Controller:
                 db.set_actor_task_error(task_id, error_msg)
                 db.set_pipeline_status(pipeline_id, PipelineStatus.FAILED)
                 db.set_pipeline_error(pipeline_id, error_msg)
+                self._finalize_mlflow_run(db, pipeline_id, "FAILED")
                 active_tasks.pop(actor_id, None)
                 scheduler.remove_pipeline(pipeline_id)
                 if progress_display:

--- a/rapidfireai/evals/scheduling/controller.py
+++ b/rapidfireai/evals/scheduling/controller.py
@@ -1030,8 +1030,21 @@ class Controller:
                 ordered_metrics,
             )
 
-            # Update pipeline status
-            db.set_pipeline_status(pipeline_id, PipelineStatus.COMPLETED)
+            # Preserve terminal non-COMPLETED states. STOPPED pipelines
+            # (IC stop or Optuna prune) have already had their dispatcher
+            # status set to STOPPED and their MLflow run terminated with
+            # KILLED by the originating handler. Phase 8 still needs to
+            # publish their partial final metrics to ``final_results`` /
+            # the dashboard, but it must NOT flip the dispatcher status
+            # to COMPLETED or the MLflow status from KILLED -> FINISHED
+            # -- doing so would undo the dispatcher <-> MLflow parity fix
+            # and make stopped/pruned pipelines look like clean finishes.
+            # FAILED and DELETED are already filtered out at the top of
+            # the loop, so the only terminal non-COMPLETED state that
+            # reaches us here is STOPPED.
+            was_stopped = pipeline_status == PipelineStatus.STOPPED.value
+            if not was_stopped:
+                db.set_pipeline_status(pipeline_id, PipelineStatus.COMPLETED)
             if progress_display:
                 # Update display with final metrics to ensure all metrics are shown.
                 # Exclude config/info keys — they are already shown in the metadata columns
@@ -1054,7 +1067,7 @@ class Controller:
 
                 progress_display.update_pipeline(
                     pipeline_id,
-                    status="COMPLETED",
+                    status="STOPPED" if was_stopped else "COMPLETED",
                     metrics=display_metrics
                 )
 
@@ -1096,13 +1109,27 @@ class Controller:
                                 except Exception as e:
                                     self.logger.warning(f"Could not log final metric {metric_name}_confidence_interval to MetricLogger: {e}")
 
-                        try:
-                            # COMPLETED dispatcher status -> MLflow FINISHED.
-                            # Explicit for clarity; matches the dispatcher ->
-                            # MLflow mapping in metric_mlflow_manager.
-                            self.metric_manager.end_run(metric_run_id, status="FINISHED")
-                        except Exception as e:
-                            self.logger.debug(f"Failed to end MetricLogger run {metric_run_id}: {e}")
+                        if was_stopped:
+                            # The MLflow run was already terminated as KILLED
+                            # by _finalize_mlflow_run() at the IC-stop /
+                            # Optuna-prune site. Calling end_run(FINISHED)
+                            # here would POST a SetTerminated(FINISHED) that
+                            # flips KILLED -> FINISHED on the server,
+                            # undoing the dispatcher <-> MLflow parity fix.
+                            # The partial final metrics logged just above
+                            # still land on the existing KILLED run.
+                            self.logger.debug(
+                                f"Skipping end_run for stopped pipeline {pipeline_id}: "
+                                f"MLflow run {metric_run_id} is already terminal (KILLED)."
+                            )
+                        else:
+                            try:
+                                # COMPLETED dispatcher status -> MLflow FINISHED.
+                                # Explicit for clarity; matches the dispatcher ->
+                                # MLflow mapping in metric_mlflow_manager.
+                                self.metric_manager.end_run(metric_run_id, status="FINISHED")
+                            except Exception as e:
+                                self.logger.debug(f"Failed to end MetricLogger run {metric_run_id}: {e}")
                 except Exception as e:
                     self.logger.debug(f"Failed to log final metrics to MetricLogger for pipeline {pipeline_id}: {e}")
 

--- a/rapidfireai/evals/scheduling/interactive_control.py
+++ b/rapidfireai/evals/scheduling/interactive_control.py
@@ -208,6 +208,22 @@ class InteractiveControlHandler:
         # Update database status
         db.set_pipeline_status(pipeline_id, PipelineStatus.ONGOING)
 
+        # Counterpart of _handle_stop's end_run(KILLED): flip the MLflow run
+        # back to RUNNING so the dashboard stops showing STOPPED for a
+        # pipeline that is once again active. Mirrors the try/except pattern
+        # used elsewhere -- MLflow trouble must not fail the IC op.
+        metric_run_id = pipeline.get("metric_run_id") if pipeline else None
+        if self.metric_manager and metric_run_id:
+            try:
+                self.metric_manager.restart_run(metric_run_id)
+                self.logger.info(
+                    f"Restarted MLflow run {metric_run_id} (status -> RUNNING) for resumed pipeline {pipeline_id}"
+                )
+            except Exception as e:
+                self.logger.warning(
+                    f"Failed to restart MLflow run for resumed pipeline {pipeline_id}: {e}"
+                )
+
         # Update display
         if progress_display:
             progress_display.update_pipeline(pipeline_id, status="ONGOING")

--- a/rapidfireai/evals/scheduling/interactive_control.py
+++ b/rapidfireai/evals/scheduling/interactive_control.py
@@ -156,6 +156,21 @@ class InteractiveControlHandler:
         # Update database status
         db.set_pipeline_status(pipeline_id, PipelineStatus.STOPPED)
 
+        # Terminate the MLflow run with KILLED so the dashboard matches the
+        # notebook table (which now shows STOPPED). Mirrors _handle_delete's
+        # try/except pattern: MLflow trouble must not fail the IC op.
+        if self.metric_manager:
+            try:
+                pipeline = db.get_pipeline(pipeline_id)
+                metric_run_id = pipeline.get("metric_run_id") if pipeline else None
+                if metric_run_id:
+                    self.metric_manager.end_run(metric_run_id, status="KILLED")
+                    self.logger.info(
+                        f"Marked MLflow run {metric_run_id} as KILLED for stopped pipeline {pipeline_id}"
+                    )
+            except Exception as e:
+                self.logger.warning(f"Failed to end MLflow run for stopped pipeline {pipeline_id}: {e}")
+
         # Update display
         if progress_display:
             progress_display.update_pipeline(pipeline_id, status="STOPPED")
@@ -604,6 +619,30 @@ class InteractiveControlHandler:
                 if hasattr(model_config, "sampling_params") and model_config.sampling_params:
                     sampling_str = json.dumps(model_config.sampling_params) if isinstance(model_config.sampling_params, dict) else str(model_config.sampling_params)
                     self.metric_manager.log_param(metric_run_id, "sampling_params", sampling_str)
+
+                # Seed shard-progress tags so the dashboard's Shards
+                # column renders "0/N" -> "k/N" -> "N/N" for this clone.
+                # Clones always start fresh at shard 0 (see the
+                # ``scheduler.add_pipeline(..., shards_completed=0)``
+                # call later in this method); the per-shard bump that
+                # advances ``rapidfire.progress.current`` lives in the
+                # controller loop (``controller.py``: after
+                # ``db.set_pipeline_progress``). Without this seeding,
+                # cloned runs would render "-" in the Shards column even
+                # though they're advancing -- the column renderer
+                # requires *both* tags to be present.
+                try:
+                    self.metric_manager.set_tag(
+                        metric_run_id, "rapidfire.progress.total", str(num_shards)
+                    )
+                    self.metric_manager.set_tag(
+                        metric_run_id, "rapidfire.progress.current", "0"
+                    )
+                except Exception as tag_err:
+                    self.logger.warning(
+                        f"Failed to seed progress tags for cloned pipeline "
+                        f"{new_pipeline_id}: {tag_err}"
+                    )
 
                 self.logger.info(f"Created metric run {metric_run_id} for cloned pipeline {new_pipeline_id}")
             except Exception as e:

--- a/rapidfireai/fit/backend/controller.py
+++ b/rapidfireai/fit/backend/controller.py
@@ -119,6 +119,37 @@ class Controller:
                 f"Failed to terminate MLflow run for run {run_id} (status={mlflow_status}): {e}"
             )
 
+    def _restart_mlflow_run(self, run_id: int) -> None:
+        """Flip the MLflow run associated with ``run_id`` back to ``RUNNING``.
+
+        Counterpart of :meth:`_finalize_mlflow_run`: the IC stop path
+        terminates the MLflow run with ``KILLED`` so the dashboard mirrors
+        the notebook table; resuming must put the run back into
+        ``RUNNING`` so the dashboard stops showing ``STOPPED`` for a run
+        that is once again training. Without this call, the resumed run
+        would render as ``STOPPED`` on the dashboard for the rest of its
+        lifetime (until clean completion / failure / re-stop fires
+        another ``end_run``).
+
+        Best-effort: any failure is logged but never propagated -- a
+        stale dashboard cell must not abort training.
+        """
+        if not self.metric_logger:
+            return
+        try:
+            run = self.db.get_run(run_id)
+            metric_run_id = run.get("metric_run_id") if run else None
+            if not metric_run_id:
+                return
+            self.metric_logger.restart_run(metric_run_id)
+            self.logger.info(
+                f"Restarted MLflow run {metric_run_id} (status -> RUNNING) for run {run_id}"
+            )
+        except Exception as e:
+            self.logger.warning(
+                f"Failed to restart MLflow run for run {run_id}: {e}"
+            )
+
     def _set_progress_tags(
         self,
         metric_run_id: str | None,
@@ -392,6 +423,11 @@ class Controller:
                     status=RunStatus.ONGOING,
                     ended_by="",
                 )
+                # Counterpart of the STOPPED branch's end_run(KILLED) call
+                # above: flip the MLflow run back to RUNNING so the
+                # dashboard agrees with the notebook table (ONGOING)
+                # instead of remaining stuck at STOPPED.
+                self._restart_mlflow_run(run_id)
                 self.db.set_ic_ops_task_status(
                     run_state["task_id"], TaskStatus.COMPLETED
                 )

--- a/rapidfireai/fit/backend/controller.py
+++ b/rapidfireai/fit/backend/controller.py
@@ -119,6 +119,43 @@ class Controller:
                 f"Failed to terminate MLflow run for run {run_id} (status={mlflow_status}): {e}"
             )
 
+    def _set_progress_tags(
+        self,
+        metric_run_id: str | None,
+        *,
+        current: int | None = None,
+        total: int | None = None,
+    ) -> None:
+        """Mirror chunk progress to MLflow tags so the dashboard's Shards
+        column can render ``current/total`` for fit-mode runs.
+
+        We use tags (not params) because ``current`` is mutable across
+        chunks, and tags are MLflow's only mutable per-run key/value
+        primitive. The frontend reads ``rapidfire.progress.current`` and
+        ``rapidfire.progress.total`` (see
+        ``RunShardsCellRenderer.tsx``). This mirrors the seeding/update
+        pattern used by the evals controller -- keep the two in sync.
+
+        Any backend errors are logged but never propagated: a stale
+        Shards cell must not take down training.
+        """
+        if not self.metric_logger or not metric_run_id:
+            return
+        try:
+            if total is not None:
+                self.metric_logger.set_tag(
+                    metric_run_id, "rapidfire.progress.total", str(total)
+                )
+            if current is not None:
+                self.metric_logger.set_tag(
+                    metric_run_id, "rapidfire.progress.current", str(current)
+                )
+        except Exception as e:
+            self.logger.warning(
+                f"Could not set rapidfire.progress tags on MLflow run "
+                f"{metric_run_id}: {e}"
+            )
+
     def _create_models(
         self,
         param_config: AutoMLAlgorithm | dict[str, Any],
@@ -222,6 +259,15 @@ class Controller:
                     self.metric_logger.log_param(
                         metric_run_id, "parent-run", str(cloned_from)
                     )
+                # Seed the Shards-column tags so the dashboard renders
+                # ``0/num_chunks`` immediately on run creation, instead
+                # of waiting for the first chunk to complete. The fit
+                # scheduler tracks chunks per epoch (it calls
+                # ``reset_run`` at epoch boundaries), so ``total`` is
+                # ``num_chunks`` -- not ``num_chunks * num_epochs``.
+                self._set_progress_tags(
+                    metric_run_id, current=0, total=num_chunks
+                )
                 self.logger.debug(
                     f"Populated MetricLogger with model config info for run {run_id}."
                 )
@@ -778,6 +824,16 @@ class Controller:
                         num_epochs_completed=num_epochs_completed,
                     )
 
+                    # Advance the Shards-column tag for this run. ``total``
+                    # is already seeded in ``_create_models`` and never
+                    # changes for fit runs, so we only update ``current``.
+                    # Epoch rollover is handled below (after
+                    # ``scheduler.reset_run``) by resetting current to 0.
+                    self._set_progress_tags(
+                        run_details.get("metric_run_id"),
+                        current=new_chunks_visited,
+                    )
+
                     # Update progress
                     progress_percentage = (
                         (
@@ -860,6 +916,14 @@ class Controller:
                         self.db.set_run_details(
                             run_id=run_id, num_chunks_visited_curr_epoch=0
                         )
+                        # The scheduler tracks chunks per-epoch, so reset
+                        # the Shards tag to ``0/num_chunks`` for the new
+                        # epoch. Without this the cell would be stuck at
+                        # ``num_chunks/num_chunks`` for the rest of the
+                        # run, hiding the rollover from users.
+                        self._set_progress_tags(
+                            run_details.get("metric_run_id"), current=0
+                        )
                         self.logger.info(
                             f"Run {run_id} has completed epoch ({new_chunks_visited}/{num_chunks} chunks)"
                         )
@@ -915,6 +979,16 @@ class Controller:
                             "num_chunks_visited_curr_epoch"
                         ]
                         scheduler.add_run(run_info, chunks_visited)
+                        # Re-seed Shards-column tags when an IC Op
+                        # resumes or revives a run. ``_create_models``
+                        # only fires for brand-new run IDs; without
+                        # this, resumed runs would render ``-`` until
+                        # their next chunk completes.
+                        self._set_progress_tags(
+                            run_details.get("metric_run_id"),
+                            current=chunks_visited,
+                            total=num_chunks,
+                        )
                         self.logger.debug(
                             f"Added run {run_id} to scheduler with {chunks_visited} chunks visited"
                         )

--- a/rapidfireai/fit/backend/controller.py
+++ b/rapidfireai/fit/backend/controller.py
@@ -94,6 +94,31 @@ class Controller:
         self.metric_logger.get_experiment(self.experiment_name)
         self.logger.debug("Controller initialized")
 
+    def _finalize_mlflow_run(self, run_id: int, mlflow_status: str) -> None:
+        """Terminate the MLflow run associated with ``run_id`` using ``mlflow_status``.
+
+        Best-effort: any failure is logged but never propagated. ``mlflow_status``
+        must be one of MLflow's ``RunStatus`` strings (``"FINISHED"``, ``"FAILED"``,
+        ``"KILLED"``). See ``DISPATCHER_TO_MLFLOW_STATUS`` in
+        ``rapidfireai.utils.metric_mlflow_manager`` for the dispatcher -> MLflow
+        mapping used here.
+        """
+        if not self.metric_logger:
+            return
+        try:
+            run = self.db.get_run(run_id)
+            metric_run_id = run.get("metric_run_id") if run else None
+            if not metric_run_id:
+                return
+            self.metric_logger.end_run(metric_run_id, status=mlflow_status)
+            self.logger.info(
+                f"Marked MLflow run {metric_run_id} as {mlflow_status} for run {run_id}"
+            )
+        except Exception as e:
+            self.logger.warning(
+                f"Failed to terminate MLflow run for run {run_id} (status={mlflow_status}): {e}"
+            )
+
     def _create_models(
         self,
         param_config: AutoMLAlgorithm | dict[str, Any],
@@ -211,7 +236,10 @@ class Controller:
                 print(msg)
                 if metric_run_id:
                     try:
-                        self.metric_logger.end_run(metric_run_id)
+                        # The tracking run never had a successful start, so
+                        # record it as FAILED rather than letting MLflow's
+                        # default FINISHED state mislead the dashboard.
+                        self.metric_logger.end_run(metric_run_id, status="FAILED")
                     except Exception:
                         pass
                 self.logger.error(msg, exc_info=True)
@@ -285,6 +313,9 @@ class Controller:
                     status=RunStatus.STOPPED,
                     ended_by=RunEndedBy.INTERACTIVE_CONTROL,
                 )
+                # Mirror dispatcher STOPPED into MLflow as KILLED so the
+                # dashboard text agrees with the user-facing CLI table.
+                self._finalize_mlflow_run(run_id, "KILLED")
                 self.db.set_ic_ops_task_status(
                     run_state["task_id"], TaskStatus.COMPLETED
                 )
@@ -779,6 +810,9 @@ class Controller:
                                     status=RunStatus.STOPPED,
                                     ended_by=RunEndedBy.OPTUNA_PRUNED,
                                 )
+                                # Optuna prune -> dispatcher STOPPED -> MLflow KILLED
+                                # (intentional programmatic termination).
+                                self._finalize_mlflow_run(run_id, "KILLED")
                                 self._clear_run_from_shm(run_id)
                                 self.logger.info(f"Optuna pruned run {run_id} after chunk {chunk_id}")
                                 if decision.replacement_config:
@@ -808,6 +842,11 @@ class Controller:
                             status=RunStatus.COMPLETED,
                             ended_by=RunEndedBy.EPOCH_COMPLETED,
                         )
+                        # Clean completion -> dispatcher COMPLETED -> MLflow FINISHED.
+                        # This is fit-mode's only successful exit; previously the run
+                        # was left RUNNING on the server until something else (e.g.
+                        # experiment_utils.end_experiment) flushed it.
+                        self._finalize_mlflow_run(run_id, "FINISHED")
                         self.logger.info(
                             f"Run {run_id} has completed all its epochs - "
                             f"steps {run_details['completed_steps']}/{run_details['total_steps']}"

--- a/rapidfireai/fit/backend/worker.py
+++ b/rapidfireai/fit/backend/worker.py
@@ -693,6 +693,23 @@ class Worker:
                             status=RunStatus.FAILED,
                             error=str(e) + traceback.format_exc(),
                         )
+                        # Mirror the dispatcher FAILED state into MLflow so the
+                        # dashboard agrees with the user-facing CLI table.
+                        # Best-effort: do not let MLflow trouble propagate.
+                        try:
+                            run_details = self.db.get_run(run_id)
+                            metric_run_id = (
+                                run_details.get("metric_run_id") if run_details else None
+                            )
+                            if self.metric_logger and metric_run_id:
+                                self.metric_logger.end_run(metric_run_id, status="FAILED")
+                                self.logger.info(
+                                    f"Marked MLflow run {metric_run_id} as FAILED for run {run_id}"
+                                )
+                        except Exception as mlflow_err:
+                            self.logger.warning(
+                                f"Failed to terminate MLflow run for failed run {run_id}: {mlflow_err}"
+                            )
                         self.db.set_worker_task_status(
                             self.worker_id, TaskStatus.FAILED
                         )

--- a/rapidfireai/fit/db/rf_db.py
+++ b/rapidfireai/fit/db/rf_db.py
@@ -120,10 +120,41 @@ class RfDb:
             commit=True,
         )
 
-        # mark ongoing and new Runs as failed
-        all_runs = self.get_runs_by_status([RunStatus.ONGOING, RunStatus.NEW]).keys()
+        # mark ongoing and new Runs as failed, and terminate the matching
+        # MLflow runs with FAILED so the dashboard reflects the recovered
+        # state (otherwise stranded runs would remain RUNNING in MLflow
+        # forever). RFMetricLogger is imported lazily to avoid a circular
+        # import on module load.
+        all_runs_dict = self.get_runs_by_status([RunStatus.ONGOING, RunStatus.NEW])
+        all_runs = all_runs_dict.keys()
+        metric_logger = None
+        if all_runs:
+            try:
+                from rapidfireai.utils.metric_rfmetric_manager import RFMetricLogger
+
+                running_exp = None
+                try:
+                    running_exp = self.get_running_experiment()
+                except Exception:
+                    running_exp = None
+                if running_exp:
+                    metric_logger = RFMetricLogger(
+                        RFMetricLogger.get_default_metric_loggers(
+                            experiment_name=running_exp["experiment_name"]
+                        )
+                    )
+            except Exception:
+                metric_logger = None
         for run_id in all_runs:
             self.set_run_status(run_id, RunStatus.FAILED)
+            if metric_logger is not None:
+                metric_run_id = all_runs_dict[run_id].get("metric_run_id")
+                if metric_run_id:
+                    try:
+                        metric_logger.end_run(metric_run_id, status="FAILED")
+                    except Exception:
+                        # Best-effort: stranded-run recovery must not fail.
+                        pass
 
         # reset all interactive control tasks
         all_ic_ops_tasks = self.get_scheduled_ic_ops_tasks()

--- a/rapidfireai/fit/utils/experiment_utils.py
+++ b/rapidfireai/fit/utils/experiment_utils.py
@@ -86,15 +86,34 @@ class ExperimentUtils:
         # disable warnings from notebook
         self._disable_ml_warnings_display()
 
-        # Clear any existing MLflow context before starting new experiment
-        # Only if using MLflow backend
+        # Clear any existing MLflow context before starting new experiment.
+        # Only if using MLflow backend. We must NOT clobber a terminal status
+        # the controller / worker / IC handler may have already set (KILLED,
+        # FAILED). Fetch the server-side status first; if the run is already
+        # terminal, pass that same status to mlflow.end_run() so the fluent
+        # API's SetTerminated call is idempotent. Otherwise fall back to the
+        # default (FINISHED) for genuinely RUNNING leftovers.
         if RF_MLFLOW_ENABLED=="true":
             import mlflow  # Lazy import to avoid connection attempts in tensorboard-only mode
+            from mlflow.tracking import MlflowClient
 
             try:
-                if mlflow.active_run():
+                active = mlflow.active_run()
+                if active:
                     print("Clearing existing MLflow context before starting new experiment")
-                    mlflow.end_run()
+                    existing_status = None
+                    try:
+                        existing_status = (
+                            MlflowClient(MLflowConfig.URL)
+                            .get_run(active.info.run_id)
+                            .info.status
+                        )
+                    except Exception:
+                        pass
+                    if existing_status in ("KILLED", "FAILED", "FINISHED"):
+                        mlflow.end_run(status=existing_status)
+                    else:
+                        mlflow.end_run()
             except Exception as e:
                 print(f"Error clearing existing MLflow context: {e}")
 
@@ -214,14 +233,30 @@ class ExperimentUtils:
         self.db.set_experiment_status(current_experiment["experiment_id"], ExperimentStatus.COMPLETED)
         self.db.reset_all_tables()
 
-        # Clear MLflow context only if using MLflow backend
+        # Clear MLflow context only if using MLflow backend. Same idempotent
+        # pattern as create_experiment: preserve any terminal status the
+        # controller / worker / IC handler already set on the active run.
         if RF_MLFLOW_ENABLED=="true":
             import mlflow  # Lazy import to avoid connection attempts in tensorboard-only mode
+            from mlflow.tracking import MlflowClient
 
             try:
-                if mlflow.active_run():
+                active = mlflow.active_run()
+                if active:
                     print("Ending active MLflow run before ending experiment")
-                    mlflow.end_run()
+                    existing_status = None
+                    try:
+                        existing_status = (
+                            MlflowClient(MLflowConfig.URL)
+                            .get_run(active.info.run_id)
+                            .info.status
+                        )
+                    except Exception:
+                        pass
+                    if existing_status in ("KILLED", "FAILED", "FINISHED"):
+                        mlflow.end_run(status=existing_status)
+                    else:
+                        mlflow.end_run()
 
                 # Also clear context through RFMetricLogger if available
                 try:

--- a/rapidfireai/fit/utils/experiment_utils.py
+++ b/rapidfireai/fit/utils/experiment_utils.py
@@ -93,25 +93,44 @@ class ExperimentUtils:
         # terminal, pass that same status to mlflow.end_run() so the fluent
         # API's SetTerminated call is idempotent. Otherwise fall back to the
         # default (FINISHED) for genuinely RUNNING leftovers.
+        #
+        # If the server-side lookup itself fails (network blip / transient
+        # MLflow outage) we must not fall back to mlflow.end_run() either:
+        # its default status is FINISHED, which would clobber any prior
+        # KILLED / FAILED state we couldn't read. In that case we clear
+        # only the local fluent active-run stack so the new experiment
+        # can claim the slot without making any server-side termination
+        # call.
         if RF_MLFLOW_ENABLED=="true":
             import mlflow  # Lazy import to avoid connection attempts in tensorboard-only mode
             from mlflow.tracking import MlflowClient
+            from rapidfireai.utils.metric_mlflow_manager import (
+                clear_local_mlflow_active_run_stack,
+            )
 
             try:
                 active = mlflow.active_run()
                 if active:
                     print("Clearing existing MLflow context before starting new experiment")
                     existing_status = None
+                    get_run_failed = False
                     try:
                         existing_status = (
                             MlflowClient(MLflowConfig.URL)
                             .get_run(active.info.run_id)
                             .info.status
                         )
-                    except Exception:
-                        pass
+                    except Exception as get_err:
+                        get_run_failed = True
+                        print(
+                            f"Could not fetch server-side status for MLflow run "
+                            f"{active.info.run_id}: {get_err}. Clearing local "
+                            f"fluent stack only to preserve any prior terminal status."
+                        )
                     if existing_status in ("KILLED", "FAILED", "FINISHED"):
                         mlflow.end_run(status=existing_status)
+                    elif get_run_failed:
+                        clear_local_mlflow_active_run_stack()
                     else:
                         mlflow.end_run()
             except Exception as e:
@@ -236,25 +255,39 @@ class ExperimentUtils:
         # Clear MLflow context only if using MLflow backend. Same idempotent
         # pattern as create_experiment: preserve any terminal status the
         # controller / worker / IC handler already set on the active run.
+        # When the server-side lookup fails we clear only the local fluent
+        # stack -- never fall through to mlflow.end_run()'s FINISHED
+        # default, which would clobber any prior KILLED / FAILED state.
         if RF_MLFLOW_ENABLED=="true":
             import mlflow  # Lazy import to avoid connection attempts in tensorboard-only mode
             from mlflow.tracking import MlflowClient
+            from rapidfireai.utils.metric_mlflow_manager import (
+                clear_local_mlflow_active_run_stack,
+            )
 
             try:
                 active = mlflow.active_run()
                 if active:
                     print("Ending active MLflow run before ending experiment")
                     existing_status = None
+                    get_run_failed = False
                     try:
                         existing_status = (
                             MlflowClient(MLflowConfig.URL)
                             .get_run(active.info.run_id)
                             .info.status
                         )
-                    except Exception:
-                        pass
+                    except Exception as get_err:
+                        get_run_failed = True
+                        print(
+                            f"Could not fetch server-side status for MLflow run "
+                            f"{active.info.run_id}: {get_err}. Clearing local "
+                            f"fluent stack only to preserve any prior terminal status."
+                        )
                     if existing_status in ("KILLED", "FAILED", "FINISHED"):
                         mlflow.end_run(status=existing_status)
+                    elif get_run_failed:
+                        clear_local_mlflow_active_run_stack()
                     else:
                         mlflow.end_run()
 

--- a/rapidfireai/frontend/src/experiment-tracking/components/RunStatusIcon.tsx
+++ b/rapidfireai/frontend/src/experiment-tracking/components/RunStatusIcon.tsx
@@ -1,4 +1,10 @@
-import { CheckCircleIcon, ClockIcon, XCircleIcon, useDesignSystemTheme } from '@databricks/design-system';
+import {
+  CheckCircleIcon,
+  ClockIcon,
+  StopCircleIcon,
+  XCircleIcon,
+  useDesignSystemTheme,
+} from '@databricks/design-system';
 
 const ErrorIcon = () => {
   const { theme } = useDesignSystemTheme();
@@ -10,11 +16,22 @@ const FinishedIcon = () => {
   return <CheckCircleIcon css={{ color: theme.colors.textValidationSuccess }} />;
 };
 
+// KILLED is the MLflow native enum value the RapidFire fork uses for an
+// intentionally stopped run (user IC-stop, Optuna prune, etc.). It is
+// semantically distinct from FAILED -- the run did not error, it was
+// asked to halt -- so we render it with the warning (amber) color and a
+// stop-circle icon rather than the red error icon used for FAILED.
+const StoppedIcon = () => {
+  const { theme } = useDesignSystemTheme();
+  return <StopCircleIcon css={{ color: theme.colors.textValidationWarning }} />;
+};
+
 export const RunStatusIcon = ({ status }: { status: string }) => {
   switch (status) {
     case 'FAILED':
-    case 'KILLED':
       return <ErrorIcon />;
+    case 'KILLED':
+      return <StoppedIcon />;
     case 'FINISHED':
       return <FinishedIcon />;
     case 'SCHEDULED':

--- a/rapidfireai/frontend/src/experiment-tracking/components/experiment-page/components/runs/cells/DateCellRenderer.tsx
+++ b/rapidfireai/frontend/src/experiment-tracking/components/experiment-page/components/runs/cells/DateCellRenderer.tsx
@@ -2,15 +2,20 @@ import { Theme } from '@emotion/react';
 import React from 'react';
 import Utils from '../../../../../../common/utils/Utils';
 import { RunRowDateAndNestInfo } from '../../../utils/experimentPage.row-types';
-import { RunStatusIcon } from '../../../../RunStatusIcon';
 import { useIntl } from 'react-intl';
 
 export interface DateCellRendererProps {
   value: RunRowDateAndNestInfo;
 }
 
+// The status icon used to live here as a prefix, but it has moved into
+// its own dedicated Status column (see RunStatusCellRenderer) so that
+// users can scan a run's lifecycle state without parsing the "Created"
+// timestamp. We intentionally do not render an icon here anymore --
+// rendering both would duplicate the visual signal and waste a column's
+// worth of horizontal space.
 export const DateCellRenderer = React.memo(({ value }: DateCellRendererProps) => {
-  const { startTime, referenceTime, runStatus } = value || {};
+  const { startTime, referenceTime } = value || {};
   const intl = useIntl();
   if (!startTime) {
     return <>-</>;
@@ -18,7 +23,6 @@ export const DateCellRenderer = React.memo(({ value }: DateCellRendererProps) =>
 
   return (
     <span css={styles.cellWrapper} title={Utils.formatTimestamp(startTime, intl)}>
-      <RunStatusIcon status={runStatus} />
       {Utils.timeSinceStr(startTime, referenceTime)}
     </span>
   );

--- a/rapidfireai/frontend/src/experiment-tracking/components/experiment-page/components/runs/cells/RunShardsCellRenderer.tsx
+++ b/rapidfireai/frontend/src/experiment-tracking/components/experiment-page/components/runs/cells/RunShardsCellRenderer.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { ICellRendererParams } from '@ag-grid-community/core';
+import { RunRowType } from '../../../utils/experimentPage.row-types';
+
+/**
+ * Cell renderer for the shards-progress column in the experiment runs table.
+ *
+ * Reads two MLflow tags written by the evals controller (see
+ * ``rapidfireai/evals/scheduling/controller.py`` -- ``set_tag`` calls for
+ * ``rapidfire.progress.current`` and ``rapidfire.progress.total``) and
+ * renders them as ``current/total`` (e.g. ``2/4``).
+ *
+ * Falls back to ``-`` when either tag is missing -- e.g. fit-mode runs
+ * (which don't emit these tags yet) or grouped/aggregate rows.
+ */
+const TAG_CURRENT = 'rapidfire.progress.current';
+const TAG_TOTAL = 'rapidfire.progress.total';
+
+export interface RunShardsCellRendererProps extends ICellRendererParams {
+  data: RunRowType;
+}
+
+export const RunShardsCellRenderer = React.memo(({ data }: RunShardsCellRendererProps) => {
+  if (!data || !data.tags) {
+    return <>-</>;
+  }
+  const current = data.tags[TAG_CURRENT]?.value;
+  const total = data.tags[TAG_TOTAL]?.value;
+  if (current === undefined || total === undefined) {
+    return <>-</>;
+  }
+  return <>{`${current}/${total}`}</>;
+});

--- a/rapidfireai/frontend/src/experiment-tracking/components/experiment-page/components/runs/cells/RunShardsCellRenderer.tsx
+++ b/rapidfireai/frontend/src/experiment-tracking/components/experiment-page/components/runs/cells/RunShardsCellRenderer.tsx
@@ -5,13 +5,16 @@ import { RunRowType } from '../../../utils/experimentPage.row-types';
 /**
  * Cell renderer for the shards-progress column in the experiment runs table.
  *
- * Reads two MLflow tags written by the evals controller (see
- * ``rapidfireai/evals/scheduling/controller.py`` -- ``set_tag`` calls for
- * ``rapidfire.progress.current`` and ``rapidfire.progress.total``) and
- * renders them as ``current/total`` (e.g. ``2/4``).
+ * Reads two MLflow tags written by both the evals controller (see
+ * ``rapidfireai/evals/scheduling/controller.py``) and the fit controller
+ * (see ``rapidfireai/fit/backend/controller.py`` --
+ * ``_set_progress_tags``) and renders them as ``current/total``
+ * (e.g. ``2/4``). For fit-mode runs ``total`` is ``num_chunks`` and
+ * ``current`` is chunks completed in the current epoch (the scheduler
+ * resets it at epoch boundaries).
  *
- * Falls back to ``-`` when either tag is missing -- e.g. fit-mode runs
- * (which don't emit these tags yet) or grouped/aggregate rows.
+ * Falls back to ``-`` when either tag is missing -- e.g. grouped /
+ * aggregate rows, or legacy runs created before this tagging was added.
  */
 const TAG_CURRENT = 'rapidfire.progress.current';
 const TAG_TOTAL = 'rapidfire.progress.total';

--- a/rapidfireai/frontend/src/experiment-tracking/components/experiment-page/components/runs/cells/RunStatusCellRenderer.tsx
+++ b/rapidfireai/frontend/src/experiment-tracking/components/experiment-page/components/runs/cells/RunStatusCellRenderer.tsx
@@ -1,0 +1,108 @@
+import { Theme } from '@emotion/react';
+import React from 'react';
+import { FormattedMessage } from 'react-intl';
+import { Typography } from '@databricks/design-system';
+import { RunStatusIcon } from '../../../../RunStatusIcon';
+
+/**
+ * Cell renderer for the run-status column in the experiment runs table.
+ *
+ * In the RapidFire fork, the dispatcher DB is the source of truth for
+ * run/pipeline status text. The notebook progress table uses the
+ * dispatcher's vocabulary (COMPLETED / STOPPED / ONGOING / NEW /
+ * FAILED), while MLflow stores its own enum (FINISHED / KILLED /
+ * RUNNING / SCHEDULED / FAILED). This cell -- mirroring
+ * RunViewStatusBox in the run detail page -- relabels MLflow's words
+ * to the dispatcher's, so the experiment table and the notebook table
+ * read identically.
+ *
+ * Colors:
+ * - FINISHED (COMPLETED) -> success/green
+ * - KILLED   (STOPPED)   -> warning/amber (intentional halt, not an error)
+ * - FAILED               -> error/red
+ * - RUNNING  (ONGOING)   -> info/secondary (matches the neutral clock icon)
+ * - SCHEDULED (NEW)      -> info/secondary (matches the neutral clock icon)
+ *
+ * NOTE on ONGOING/NEW color: we briefly tried forcing the text to blue
+ * (`theme.colors.blue500`), but the matching ``ClockIcon`` in
+ * ``RunStatusIcon.tsx`` has no explicit color and inherits the
+ * design-system text color. That produced a blue-text / white-icon
+ * combo that looked broken. The cleanest answer is to keep both at
+ * ``color="info"`` (TextSecondary in the design system) so text and
+ * icon match -- visually neutral, but consistent.
+ */
+export interface RunStatusCellRendererProps {
+  value?: string;
+}
+
+const StatusLabel = ({ status }: { status?: string }) => {
+  switch (status) {
+    case 'FINISHED':
+      return (
+        <Typography.Text color="success">
+          <FormattedMessage
+            defaultMessage="COMPLETED"
+            description="Experiment runs table > Status column > Value for finished state"
+          />
+        </Typography.Text>
+      );
+    case 'KILLED':
+      return (
+        <Typography.Text color="warning">
+          <FormattedMessage
+            defaultMessage="STOPPED"
+            description="Experiment runs table > Status column > Value for killed state"
+          />
+        </Typography.Text>
+      );
+    case 'FAILED':
+      return (
+        <Typography.Text color="error">
+          <FormattedMessage
+            defaultMessage="FAILED"
+            description="Experiment runs table > Status column > Value for failed state"
+          />
+        </Typography.Text>
+      );
+    case 'RUNNING':
+      return (
+        <Typography.Text color="info">
+          <FormattedMessage
+            defaultMessage="ONGOING"
+            description="Experiment runs table > Status column > Value for running state"
+          />
+        </Typography.Text>
+      );
+    case 'SCHEDULED':
+      return (
+        <Typography.Text color="info">
+          <FormattedMessage
+            defaultMessage="NEW"
+            description="Experiment runs table > Status column > Value for scheduled state"
+          />
+        </Typography.Text>
+      );
+    default:
+      return <>{status ?? '-'}</>;
+  }
+};
+
+export const RunStatusCellRenderer = React.memo(({ value }: RunStatusCellRendererProps) => {
+  if (!value) {
+    return <>-</>;
+  }
+  return (
+    <span css={styles.cellWrapper}>
+      <RunStatusIcon status={value} />
+      <StatusLabel status={value} />
+    </span>
+  );
+});
+
+const styles = {
+  cellWrapper: (theme: Theme) => ({
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing.sm,
+  }),
+};

--- a/rapidfireai/frontend/src/experiment-tracking/components/experiment-page/utils/experimentPage.column-utils.tsx
+++ b/rapidfireai/frontend/src/experiment-tracking/components/experiment-page/utils/experimentPage.column-utils.tsx
@@ -34,6 +34,8 @@ import {
 } from '../components/runs/cells/RowActionsCellRenderer';
 import { RowActionsHeaderCellRenderer } from '../components/runs/cells/RowActionsHeaderCellRenderer';
 import { RunNameCellRenderer } from '../components/runs/cells/RunNameCellRenderer';
+import { RunShardsCellRenderer } from '../components/runs/cells/RunShardsCellRenderer';
+import { RunStatusCellRenderer } from '../components/runs/cells/RunStatusCellRenderer';
 import { LoadMoreRowRenderer } from '../components/runs/cells/LoadMoreRowRenderer';
 import {
   DatasetsCellRenderer,
@@ -113,6 +115,8 @@ export const getFrameworkComponents = () => ({
   RowActionsCellRenderer,
   RowActionsHeaderCellRenderer,
   RunNameCellRenderer,
+  RunStatusCellRenderer,
+  RunShardsCellRenderer,
   DatasetsCellRenderer,
   InteractiveControllerCellRenderer,
   AggregateMetricValueCell,
@@ -329,6 +333,41 @@ export const useRunsColumnDefinitions = ({
       flex: isRunColumnDynamicSized ? 1 : undefined,
       resizable: !isComparingRuns,
       suppressKeyboardEvent: defaultKeyboardNavigationSuppressor,
+    });
+
+    // Status column -- placed immediately after Run Name so the user can
+    // see each run's lifecycle state (COMPLETED / STOPPED / ONGOING / NEW
+    // / FAILED, after relabel) at the same glance as the run name. Sourced
+    // from the row's runStatus field (set in experimentPage.row-utils from
+    // runInfo.status). Pinned left so it stays adjacent to the run name
+    // when the user scrolls horizontally through parameter/metric columns.
+    // The cell renderer also handles the dispatcher vocabulary relabel; see
+    // RunStatusCellRenderer.tsx.
+    columns.push({
+      headerName: ATTRIBUTE_COLUMN_LABELS.STATUS,
+      colId: makeCanonicalSortKey(COLUMN_TYPES.ATTRIBUTES, ATTRIBUTE_COLUMN_LABELS.STATUS),
+      headerTooltip: ATTRIBUTE_COLUMN_LABELS.STATUS,
+      pinned: usingCompactViewport ? undefined : 'left',
+      field: 'runStatus',
+      cellRenderer: 'RunStatusCellRenderer',
+      sortable: false,
+      resizable: true,
+      initialWidth: 130,
+    });
+
+    // Shards column -- shows shard progress (e.g. "2/4") read from
+    // MLflow tags rapidfire.progress.current / rapidfire.progress.total
+    // (emitted by the evals controller). Pinned left so it stays in the
+    // visual cluster Run Name -> Status -> Shards -> Created.
+    columns.push({
+      headerName: ATTRIBUTE_COLUMN_LABELS.SHARDS,
+      colId: makeCanonicalSortKey(COLUMN_TYPES.ATTRIBUTES, ATTRIBUTE_COLUMN_LABELS.SHARDS),
+      headerTooltip: ATTRIBUTE_COLUMN_LABELS.SHARDS,
+      pinned: usingCompactViewport ? undefined : 'left',
+      cellRenderer: 'RunShardsCellRenderer',
+      sortable: false,
+      resizable: true,
+      initialWidth: 90,
     });
 
     // If we are only comparing runs, that's it - we cut off the list after the run name column.

--- a/rapidfireai/frontend/src/experiment-tracking/components/run-page/overview/RunViewStatusBox.tsx
+++ b/rapidfireai/frontend/src/experiment-tracking/components/run-page/overview/RunViewStatusBox.tsx
@@ -9,11 +9,17 @@ import type { MlflowRunStatus } from '../../../../graphql/__generated__/graphql'
  */
 export const RunViewStatusBox = ({ status }: { status: RunInfoEntity['status'] | MlflowRunStatus | null }) => {
   const { theme } = useDesignSystemTheme();
+  // KILLED (dispatcher STOPPED) is intentionally halted, not a failure, so
+  // it gets the warning (amber/yellow) palette rather than the red
+  // reserved for FAILED. See RunStatusIcon.tsx for the matching icon.
   const getTagColor = () => {
     if (status === 'FINISHED') {
       return theme.isDarkMode ? theme.colors.green800 : theme.colors.green100;
     }
-    if (status === 'KILLED' || status === 'FAILED') {
+    if (status === 'KILLED') {
+      return theme.isDarkMode ? theme.colors.yellow800 : theme.colors.yellow100;
+    }
+    if (status === 'FAILED') {
       return theme.isDarkMode ? theme.colors.red800 : theme.colors.red100;
     }
     if (status === 'SCHEDULED' || status === 'RUNNING') {
@@ -23,12 +29,22 @@ export const RunViewStatusBox = ({ status }: { status: RunInfoEntity['status'] |
     return undefined;
   };
 
+  // In the RapidFire fork, the dispatcher DB is the source of truth for
+  // run/pipeline status text shown to the user. The notebook progress
+  // table uses the dispatcher's vocabulary (COMPLETED / STOPPED /
+  // ONGOING / NEW / FAILED), while the underlying MLflow server is
+  // constrained to its own enum (FINISHED / KILLED / RUNNING /
+  // SCHEDULED / FAILED). This box relabels MLflow's native words to the
+  // dispatcher's so the dashboard and the notebook tables read
+  // identically across both fit and evals modes. See
+  // DISPATCHER_TO_MLFLOW_STATUS in
+  // rapidfireai/utils/metric_mlflow_manager.py for the mapping.
   const getStatusLabel = () => {
     if (status === 'FINISHED') {
       return (
         <Typography.Text color="success">
           <FormattedMessage
-            defaultMessage="Finished"
+            defaultMessage="COMPLETED"
             description="Run page > Overview > Run status cell > Value for finished state"
           />
         </Typography.Text>
@@ -36,9 +52,9 @@ export const RunViewStatusBox = ({ status }: { status: RunInfoEntity['status'] |
     }
     if (status === 'KILLED') {
       return (
-        <Typography.Text color="error">
+        <Typography.Text color="warning">
           <FormattedMessage
-            defaultMessage="Killed"
+            defaultMessage="STOPPED"
             description="Run page > Overview > Run status cell > Value for killed state"
           />
         </Typography.Text>
@@ -48,17 +64,23 @@ export const RunViewStatusBox = ({ status }: { status: RunInfoEntity['status'] |
       return (
         <Typography.Text color="error">
           <FormattedMessage
-            defaultMessage="Failed"
+            defaultMessage="FAILED"
             description="Run page > Overview > Run status cell > Value for failed state"
           />
         </Typography.Text>
       );
     }
+    // ONGOING / NEW are kept at ``color="info"`` (TextSecondary in the
+    // design system) so they match the neutral, uncolored ``ClockIcon``
+    // rendered by ``RunStatusIcon``. Forcing the text to blue while
+    // leaving the icon at the inherited text color produced a
+    // blue-text / white-icon mismatch -- so we deliberately render
+    // both text and icon in the same neutral tone instead.
     if (status === 'RUNNING') {
       return (
         <Typography.Text color="info">
           <FormattedMessage
-            defaultMessage="Running"
+            defaultMessage="ONGOING"
             description="Run page > Overview > Run status cell > Value for running state"
           />
         </Typography.Text>
@@ -68,7 +90,7 @@ export const RunViewStatusBox = ({ status }: { status: RunInfoEntity['status'] |
       return (
         <Typography.Text color="info">
           <FormattedMessage
-            defaultMessage="Scheduled"
+            defaultMessage="NEW"
             description="Run page > Overview > Run status cell > Value for scheduled state"
           />
         </Typography.Text>

--- a/rapidfireai/frontend/src/experiment-tracking/constants.ts
+++ b/rapidfireai/frontend/src/experiment-tracking/constants.ts
@@ -14,6 +14,8 @@ export const ATTRIBUTE_COLUMN_LABELS = {
   DURATION: 'Duration',
   USER: 'User',
   RUN_NAME: 'Run Name',
+  STATUS: 'Status',
+  SHARDS: 'Shards',
   SOURCE: 'Source',
   VERSION: 'Version',
   MODELS: 'Models',

--- a/rapidfireai/frontend/src/lang/default/en.json
+++ b/rapidfireai/frontend/src/lang/default/en.json
@@ -1076,7 +1076,7 @@
     "description": "Tag assignment modal > Title of the add tags modal"
   },
   "AM8DuO": {
-    "defaultMessage": "Failed",
+    "defaultMessage": "FAILED",
     "description": "Run page > Overview > Run status cell > Value for failed state"
   },
   "AOoWxS": {
@@ -1108,7 +1108,7 @@
     "description": "Label name for the created time under details tab on the model view page"
   },
   "AupQl+": {
-    "defaultMessage": "Killed",
+    "defaultMessage": "STOPPED",
     "description": "Run page > Overview > Run status cell > Value for killed state"
   },
   "AxdKIr": {
@@ -2244,7 +2244,7 @@
     "description": "Models table > no models present yet"
   },
   "On3g1B": {
-    "defaultMessage": "Running",
+    "defaultMessage": "ONGOING",
     "description": "Run page > Overview > Run status cell > Value for running state"
   },
   "OzyPl3": {
@@ -2887,7 +2887,7 @@
     "description": "Empty state title displayed when all models are filtered out in the logged models list page"
   },
   "X8OaXU": {
-    "defaultMessage": "Scheduled",
+    "defaultMessage": "NEW",
     "description": "Run page > Overview > Run status cell > Value for scheduled state"
   },
   "XBtNVo": {
@@ -5050,7 +5050,7 @@
     "description": "Run page > Overview > Description section > Section title"
   },
   "ujm55z": {
-    "defaultMessage": "Finished",
+    "defaultMessage": "COMPLETED",
     "description": "Run page > Overview > Run status cell > Value for finished state"
   },
   "umeTwG": {

--- a/rapidfireai/utils/metric_logger.py
+++ b/rapidfireai/utils/metric_logger.py
@@ -133,6 +133,22 @@ class MetricLogger(ABC):
         """
         return None
 
+    def restart_run(self, run_id: str) -> None:
+        """Flip a previously-terminated run back to ``RUNNING``.
+
+        Used by IC "resume" handlers: stopping a run terminates the
+        corresponding MLflow run with ``KILLED`` so the dashboard mirrors
+        the notebook table, but a subsequent resume must put that same
+        run back into ``RUNNING`` -- otherwise the dashboard stays at
+        ``STOPPED`` while the notebook (and the actual training loop)
+        progresses through new chunks/shards.
+
+        The default implementation is a no-op so backends without a
+        meaningful "status" concept (TensorBoard, Trackio) don't need to
+        implement it. MLflow overrides this with an ``UpdateRun`` call.
+        """
+        return None
+
 class MetricLoggerType(Enum):
     """Enum for MetricLogger types."""
     MLFLOW = "mlflow"

--- a/rapidfireai/utils/metric_logger.py
+++ b/rapidfireai/utils/metric_logger.py
@@ -84,12 +84,17 @@ class MetricLogger(ABC):
         pass
 
     @abstractmethod
-    def end_run(self, run_id: str) -> None:
+    def end_run(self, run_id: str, status: Optional[str] = None) -> None:
         """
         End a specific run.
 
         Args:
             run_id: Run identifier
+            status: Optional terminal status to record at the backend. MLflow
+                ``RunStatus`` string (``"FINISHED"``, ``"FAILED"``, ``"KILLED"``).
+                When ``None``, backends should fall back to their default
+                terminal state (today: MLflow ``FINISHED``) so external callers
+                that haven't been updated yet keep working.
         """
         pass
 
@@ -107,6 +112,26 @@ class MetricLogger(ABC):
     def clear_context(self) -> None:
         """Clear the tracking context (optional, not all backends need this)."""
         pass
+
+    def set_tag(self, run_id: str, key: str, value: str) -> None:
+        """
+        Set a tag on a specific run.
+
+        Unlike :meth:`log_param`, tags are mutable -- calling ``set_tag``
+        again with the same key overwrites the previous value. Used for
+        properties that evolve over a run's lifetime (e.g. progress
+        counters) that ``log_param`` cannot represent.
+
+        Args:
+            run_id: Run identifier.
+            key: Tag name.
+            value: Tag value (coerced to string by most backends).
+
+        The default implementation is a no-op so backends without a
+        native tag concept (TensorBoard, Trackio) don't need to implement
+        it. MLflow overrides this with a real ``set_tag`` call.
+        """
+        return None
 
 class MetricLoggerType(Enum):
     """Enum for MetricLogger types."""

--- a/rapidfireai/utils/metric_mlflow_manager.py
+++ b/rapidfireai/utils/metric_mlflow_manager.py
@@ -196,6 +196,47 @@ class MLflowMetricLogger(MetricLogger):
         else:
             self.logger.warning(f"MLflow run {run_id} not found, cannot terminate")
 
+    def restart_run(self, run_id: str) -> None:
+        """Flip an MLflow run that was previously terminated back to ``RUNNING``.
+
+        Counterpart of :meth:`end_run`. The IC stop handler terminates
+        the run with ``KILLED`` so the dashboard mirrors the notebook
+        table; the IC resume handler calls this to put the run back to
+        ``RUNNING`` so the dashboard stops showing ``STOPPED`` for a
+        pipeline / fit-run that is actually progressing again.
+
+        We deliberately use ``MlflowClient.update_run`` rather than
+        ``set_terminated`` here: ``set_terminated`` is semantically about
+        terminal states (its docstring says "Set a run's status to
+        terminated" even though MLflow happens to also accept ``RUNNING``
+        / ``SCHEDULED``). ``update_run`` is the explicit, future-proof
+        way to flip status in either direction.
+
+        Best-effort: any backend error is logged and swallowed because a
+        stale dashboard state must not fail the IC operation.
+        """
+        try:
+            run = self.client.get_run(run_id)
+        except Exception as e:
+            self.logger.warning(
+                f"Cannot restart MLflow run {run_id}: get_run failed ({e})"
+            )
+            return
+        if run is None:
+            self.logger.warning(
+                f"MLflow run {run_id} not found, cannot restart"
+            )
+            return
+        try:
+            self.client.update_run(run_id, status="RUNNING")
+            self.logger.info(
+                f"Restarted MLflow run {run_id} (status -> RUNNING)"
+            )
+        except Exception as e:
+            self.logger.warning(
+                f"Failed to restart MLflow run {run_id}: {e}"
+            )
+
     def set_tag(self, run_id: str, key: str, value: str) -> None:
         """Set a (mutable) tag on the MLflow run.
 

--- a/rapidfireai/utils/metric_mlflow_manager.py
+++ b/rapidfireai/utils/metric_mlflow_manager.py
@@ -4,11 +4,54 @@ import os
 import re
 import mlflow
 from mlflow.tracking import MlflowClient
-from typing import Any
+from typing import Any, Optional
 from rapidfireai.utils.metric_logger import MetricLogger, MetricLoggerType
 from rapidfireai.utils.ping import ping_server
 from rapidfireai.utils.constants import MLflowConfig
 from rapidfireai.evals.utils.logger import RFLogger
+
+
+# Dispatcher pipeline/run status -> MLflow RunStatus mapping.
+#
+# MLflow's RunInfo.status is a fixed enum (RUNNING, SCHEDULED, FINISHED,
+# FAILED, KILLED). We cannot store the dispatcher's vocabulary (COMPLETED,
+# STOPPED, ...) verbatim because the MLflow server validates submissions
+# against its own enum. We pick the closest MLflow value here and the
+# forked frontend (RunViewStatusBox.tsx) relabels them back to the
+# dispatcher's words so the dashboard text matches the notebook table.
+#
+# Both fit-mode (rapidfireai/fit/utils/constants.py::RunStatus) and
+# evals-mode (rapidfireai/evals/utils/constants.py::PipelineStatus) use
+# the same lowercase string values, so a single mapping covers both.
+#
+#   COMPLETED -> FINISHED  (clean success)
+#   STOPPED   -> KILLED    (covers user IC-stop + Optuna prune)
+#   FAILED    -> FAILED    (runtime / init / dispatch errors)
+#   DELETED   -> N/A       (handled by delete_run, never via end_run)
+DISPATCHER_TO_MLFLOW_STATUS: dict[str, str] = {
+    "completed": "FINISHED",
+    "stopped": "KILLED",
+    "failed": "FAILED",
+}
+
+
+def dispatcher_status_to_mlflow(dispatcher_status: Any) -> Optional[str]:
+    """Convert a dispatcher status (enum or string) to its MLflow RunStatus.
+
+    Accepts either a ``PipelineStatus``/``RunStatus`` enum value or a raw
+    string. Returns ``None`` when the status has no MLflow counterpart
+    (e.g. ``DELETED``, ``NEW``, ``ONGOING``) so callers can decide to skip
+    the MLflow termination.
+    """
+    if dispatcher_status is None:
+        return None
+    if hasattr(dispatcher_status, "value"):
+        key = dispatcher_status.value
+    else:
+        key = dispatcher_status
+    if not isinstance(key, str):
+        return None
+    return DISPATCHER_TO_MLFLOW_STATUS.get(key.lower())
 
 
 # MLflow only allows alphanumerics, underscores (_), dashes (-), periods (.),
@@ -110,26 +153,60 @@ class MLflowMetricLogger(MetricLogger):
             self.logger.error(f"Error getting metrics for run {run_id}: {e}")
             return {}
 
-    def end_run(self, run_id: str) -> None:
-        """End a specific run."""
+    def end_run(self, run_id: str, status: Optional[str] = None) -> None:
+        """End a specific run.
+
+        Args:
+            run_id: MLflow run identifier.
+            status: Optional MLflow ``RunStatus`` string (``"FINISHED"``,
+                ``"FAILED"``, ``"KILLED"``). When ``None``, MLflow's server
+                defaults to ``FINISHED``. Use :func:`dispatcher_status_to_mlflow`
+                to derive this from a dispatcher pipeline / run status.
+
+        See the ``DISPATCHER_TO_MLFLOW_STATUS`` map at the top of this module
+        for the dispatcher -> MLflow status mapping used by callers.
+        """
         # Check if run exists before terminating
         run = self.client.get_run(run_id)
         if run is not None:
-            # First terminate the run on the server
-            self.client.set_terminated(run_id)
+            # First terminate the run on the server. set_terminated treats
+            # status=None as "use server default (FINISHED)", which preserves
+            # existing behaviour for callers that haven't been updated.
+            if status is not None:
+                self.client.set_terminated(run_id, status=status)
+            else:
+                self.client.set_terminated(run_id)
 
-            # Then clear the local MLflow context if this is the active run
+            # Then clear the local MLflow context if this is the active run.
+            # We pass the same status to mlflow.end_run() so the fluent
+            # API doesn't POST another SetTerminated(FINISHED) that would
+            # clobber our explicit terminal state.
             try:
                 current_run = mlflow.active_run()
                 # Make sure we end the run on the correct worker
                 if current_run and current_run.info.run_id == run_id:
-                    mlflow.end_run()
+                    if status is not None:
+                        mlflow.end_run(status=status)
+                    else:
+                        mlflow.end_run()
                 else:
                     self.logger.warning(f"Run {run_id} is not the active run, no local context to clear")
             except Exception as e:
                 self.logger.error(f"Error clearing local MLflow context: {e}")
         else:
             self.logger.warning(f"MLflow run {run_id} not found, cannot terminate")
+
+    def set_tag(self, run_id: str, key: str, value: str) -> None:
+        """Set a (mutable) tag on the MLflow run.
+
+        Used for evolving per-run state (e.g. ``rapidfire.progress.current``)
+        that MLflow ``params`` cannot represent because params are
+        immutable.
+        """
+        try:
+            self.client.set_tag(run_id, key, str(value))
+        except Exception as e:
+            self.logger.warning(f"Failed to set MLflow tag {key}={value} on run {run_id}: {e}")
 
     def delete_run(self, run_id: str) -> None:
         """Delete a specific run."""
@@ -141,21 +218,33 @@ class MLflowMetricLogger(MetricLogger):
             raise ValueError(f"Run '{run_id}' not found")
 
     def clear_context(self) -> None:
-        """Clear the MLflow context by ending any active run."""
+        """Clear the MLflow context by ending any active run.
+
+        Idempotent w.r.t. server-side terminal status: if the active run is
+        already KILLED / FAILED / FINISHED on the server, we pass that same
+        status to ``mlflow.end_run()`` so the fluent API does not POST
+        another ``SetTerminated(FINISHED)`` that clobbers the explicit
+        terminal state set by the controller / worker / IC handler.
+        """
         try:
             current_run = mlflow.active_run()
             if current_run:
                 run_id = current_run.info.run_id
 
-                # Try to end the run properly using the client first
+                existing_status = None
                 try:
-                    self.client.end_run(run_id)
+                    existing_status = self.client.get_run(run_id).info.status
                 except Exception:
-                    # Fallback to global mlflow.end_run()
-                    mlflow.end_run()
-                    self.logger.info(f"Run {run_id} ended using global mlflow.end_run")
+                    pass
 
-                self.logger.info("MLflow context cleared successfully")
+                if existing_status in ("KILLED", "FAILED", "FINISHED"):
+                    mlflow.end_run(status=existing_status)
+                else:
+                    mlflow.end_run()
+
+                self.logger.info(
+                    f"MLflow context cleared for run {run_id} (status={existing_status or 'FINISHED'})"
+                )
             else:
                 self.logger.info("No active MLflow run to clear")
         except Exception as e:

--- a/rapidfireai/utils/metric_mlflow_manager.py
+++ b/rapidfireai/utils/metric_mlflow_manager.py
@@ -78,6 +78,64 @@ def _sanitize_mlflow_name(name: str) -> str:
     return _MLFLOW_NAME_INVALID_RE.sub("_", sanitized)
 
 
+def clear_local_mlflow_active_run_stack(logger: Any = None) -> None:
+    """Pop the current process's MLflow fluent active-run stack WITHOUT
+    posting a server-side ``SetTerminated``.
+
+    ``mlflow.end_run()`` (or ``mlflow.end_run(status=None)``) defaults to
+    ``FINISHED`` and fires ``SetTerminated(FINISHED)`` on the tracking
+    server. That's the right thing to do for a run we know is healthy and
+    we are intentionally finishing -- but it is the *wrong* thing to do
+    when we can't determine the server-side status (e.g. the
+    ``MlflowClient.get_run`` lookup raised). In that case the run may
+    already be in a terminal state (``KILLED`` from IC stop, ``FAILED``
+    from a worker / controller error) that the fluent default would
+    silently clobber, leaving the dashboard with a misleading
+    ``COMPLETED`` cell.
+
+    The work here mirrors ``mlflow.end_run`` minus the ``set_terminated``
+    call: pop the fluent stack so the next ``mlflow.start_run(...)`` in
+    this process succeeds, and tear down the per-run system-metrics
+    monitor MLflow may have started (otherwise it leaks).
+
+    Best-effort: MLflow's private fluent symbols (``_active_run_stack``,
+    ``_last_active_run_id``, ``run_id_to_system_metrics_monitor``) can
+    shift between MLflow versions. If any of them are missing or change
+    shape, we log and fall back to no-op rather than raise -- the next
+    ``mlflow.start_run()`` will surface a clearer error than we could
+    synthesise here, and we would rather expose that than risk marking
+    the previous run as ``FINISHED``.
+
+    ``logger`` is optional; when ``None`` we silently swallow internal
+    errors (callers that want diagnostics should pass one in).
+    """
+    try:
+        from mlflow.tracking import fluent
+        from mlflow.environment_variables import MLFLOW_RUN_ID
+
+        active_stack = fluent._active_run_stack.get()
+        if active_stack:
+            MLFLOW_RUN_ID.unset()
+            run = active_stack.pop()
+            fluent._last_active_run_id.set(run.info.run_id)
+            monitor = fluent.run_id_to_system_metrics_monitor.pop(
+                run.info.run_id, None
+            )
+            if monitor is not None:
+                try:
+                    monitor.finish()
+                except Exception:
+                    pass
+    except Exception as e:  # pragma: no cover - defensive against MLflow internals churn
+        if logger is not None:
+            try:
+                logger.warning(
+                    f"Could not clear local MLflow active-run stack: {e}"
+                )
+            except Exception:
+                pass
+
+
 class MLflowMetricLogger(MetricLogger):
     def __init__(self, tracking_uri: str, logger: RFLogger = None, init_kwargs: dict[str, Any] = None):
         """
@@ -266,6 +324,15 @@ class MLflowMetricLogger(MetricLogger):
         status to ``mlflow.end_run()`` so the fluent API does not POST
         another ``SetTerminated(FINISHED)`` that clobbers the explicit
         terminal state set by the controller / worker / IC handler.
+
+        When the server-side status lookup itself fails (network blip,
+        transient MLflow outage, etc.) we deliberately *do not* call
+        ``mlflow.end_run()`` -- that would default to ``FINISHED`` and
+        clobber any prior ``KILLED`` / ``FAILED`` state we couldn't read.
+        Instead, we clear only the local fluent active-run stack via
+        :func:`clear_local_mlflow_active_run_stack`, leaving the server's
+        view of the run untouched. The next ``mlflow.start_run(...)`` in
+        this process will still succeed.
         """
         try:
             current_run = mlflow.active_run()
@@ -273,18 +340,31 @@ class MLflowMetricLogger(MetricLogger):
                 run_id = current_run.info.run_id
 
                 existing_status = None
+                get_run_failed = False
                 try:
                     existing_status = self.client.get_run(run_id).info.status
-                except Exception:
-                    pass
+                except Exception as get_err:
+                    get_run_failed = True
+                    self.logger.warning(
+                        f"Could not fetch server-side status for MLflow run "
+                        f"{run_id} while clearing context: {get_err}. "
+                        f"Falling back to local-only stack clear to preserve "
+                        f"any prior terminal status."
+                    )
 
                 if existing_status in ("KILLED", "FAILED", "FINISHED"):
                     mlflow.end_run(status=existing_status)
+                elif get_run_failed:
+                    clear_local_mlflow_active_run_stack(self.logger)
                 else:
+                    # Server says the run is genuinely RUNNING / SCHEDULED;
+                    # default end_run() (-> FINISHED) is the correct
+                    # terminal state for an explicitly-cleared context.
                     mlflow.end_run()
 
                 self.logger.info(
-                    f"MLflow context cleared for run {run_id} (status={existing_status or 'FINISHED'})"
+                    f"MLflow context cleared for run {run_id} "
+                    f"(status={existing_status or ('UNKNOWN' if get_run_failed else 'FINISHED')})"
                 )
             else:
                 self.logger.info("No active MLflow run to clear")

--- a/rapidfireai/utils/metric_rfmetric_manager.py
+++ b/rapidfireai/utils/metric_rfmetric_manager.py
@@ -176,6 +176,24 @@ class RFMetricLogger(MetricLogger):
             else:
                 raise ValueError(f"metric_logger for {metric_logger_name} does not support log_metric")
 
+    def restart_run(self, run_id: str) -> None:
+        """Flip a previously-terminated run back to RUNNING on every
+        backend that supports it.
+
+        See :meth:`MetricLogger.restart_run` for the IC-resume use case.
+        Only the MLflow backend has a meaningful status field today; the
+        other backends inherit the no-op default. We forward the canonical
+        ``run_id`` to MLflow and the human-readable run name to the
+        others, mirroring the routing used by :meth:`end_run` /
+        :meth:`set_tag`.
+        """
+        run_name = self._get_run_name(run_id)
+        for metric_logger in self.metric_loggers.values():
+            if metric_logger.type == MetricLoggerType.MLFLOW:
+                metric_logger.restart_run(run_id)
+            else:
+                metric_logger.restart_run(run_name)
+
     def set_tag(self, run_id: str, key: str, value: str) -> None:
         """Set a tag on each backend that supports it.
 

--- a/rapidfireai/utils/metric_rfmetric_manager.py
+++ b/rapidfireai/utils/metric_rfmetric_manager.py
@@ -175,6 +175,21 @@ class RFMetricLogger(MetricLogger):
                     metric_logger.log_metric(run_name, key, value, step=step)
             else:
                 raise ValueError(f"metric_logger for {metric_logger_name} does not support log_metric")
+
+    def set_tag(self, run_id: str, key: str, value: str) -> None:
+        """Set a tag on each backend that supports it.
+
+        Tags are mutable and used for evolving per-run state (e.g. shard
+        progress). Backends without a native tag concept (TB, Trackio)
+        fall back to the no-op default implemented in
+        :class:`MetricLogger`.
+        """
+        run_name = self._get_run_name(run_id)
+        for metric_logger in self.metric_loggers.values():
+            if metric_logger.type == MetricLoggerType.MLFLOW:
+                metric_logger.set_tag(run_id, key, value)
+            else:
+                metric_logger.set_tag(run_name, key, value)
     
     def get_run_metrics(self, run_id: str) -> dict:
         """Get metrics from MetricLogger."""
@@ -183,16 +198,22 @@ class RFMetricLogger(MetricLogger):
                 return metric_logger.get_run_metrics(run_id)
         return {}
 
-    def end_run(self, run_id: str) -> None:
-        """End run in MetricLogger."""
+    def end_run(self, run_id: str, status: Optional[str] = None) -> None:
+        """End run in MetricLogger.
+
+        ``status`` is forwarded to each backend so MLflow records the terminal
+        state correctly; other backends ignore it but accept it for signature
+        parity. See :data:`DISPATCHER_TO_MLFLOW_STATUS` in
+        ``metric_mlflow_manager`` for the dispatcher -> MLflow mapping.
+        """
         run_name = self._get_run_name(run_id)
         for metric_logger_name, metric_logger in self.metric_loggers.items():
-            self.logger.info(f"Ending run: {run_id}, {run_name} in {metric_logger_name}")
+            self.logger.info(f"Ending run: {run_id}, {run_name} in {metric_logger_name} (status={status})")
             if hasattr(metric_logger, "end_run"):
                 if metric_logger.type == MetricLoggerType.MLFLOW:
-                    metric_logger.end_run(run_id)
+                    metric_logger.end_run(run_id, status=status)
                 else:
-                    metric_logger.end_run(run_name)
+                    metric_logger.end_run(run_name, status=status)
             else:
                 raise ValueError(f"metric_logger for {metric_logger_name} does not support end_run")
 

--- a/rapidfireai/utils/metric_tensorboard_manager.py
+++ b/rapidfireai/utils/metric_tensorboard_manager.py
@@ -114,8 +114,13 @@ class TensorBoardMetricLogger(MetricLogger):
         """
         return {}
     
-    def end_run(self, run_id: str) -> None:
-        """End a TensorBoard run by closing the writer."""
+    def end_run(self, run_id: str, status: Optional[str] = None) -> None:
+        """End a TensorBoard run by closing the writer.
+
+        ``status`` is accepted for signature parity with MetricLogger and is
+        ignored here -- TensorBoard has no terminal-state concept.
+        """
+        del status  # unused; kept for signature parity
         if run_id in self.writers:
             self.writers[run_id].close()
             del self.writers[run_id]

--- a/rapidfireai/utils/metric_trackio_manager.py
+++ b/rapidfireai/utils/metric_trackio_manager.py
@@ -4,7 +4,7 @@ import time
 import trackio
 import io
 from contextlib import redirect_stdout
-from typing import Any
+from typing import Any, Optional
 from rapidfireai.utils.metric_logger import MetricLogger, MetricLoggerType
 from rapidfireai.evals.utils.logger import RFLogger
 import warnings
@@ -139,10 +139,18 @@ class TrackioMetricLogger(MetricLogger):
         # Metrics are stored locally and can be viewed via trackio.show()
         return {}
 
-    def end_run(self, run_id: str) -> None:
-        """End a specific run."""
+    def end_run(self, run_id: str, status: Optional[str] = None) -> None:
+        """End a specific run.
+
+        ``status`` is accepted for signature parity with MetricLogger.
+        Trackio's ``finish()`` has no terminal-state concept, so the value
+        is logged but otherwise ignored.
+        """
         try:
-            self.logger.info(f"Ending Trackio run: {run_id}")
+            if status is not None:
+                self.logger.info(f"Ending Trackio run: {run_id} (status={status})")
+            else:
+                self.logger.info(f"Ending Trackio run: {run_id}")
             self._capture_trackio_output(self.active_runs[run_id].finish)
             # Allow background thread to complete sending data before program exit
             time.sleep(0.5)

--- a/tests/test_mlflow_status_parity.py
+++ b/tests/test_mlflow_status_parity.py
@@ -369,6 +369,226 @@ def test_idempotent_end_run_preserves_terminal_state(server_status, expected):
 
 
 # --------------------------------------------------------------------------- #
+# Regression: when the server-side MlflowClient.get_run lookup itself fails
+# (network blip, transient MLflow outage), the idempotency block must NOT
+# fall through to mlflow.end_run() -- that defaults to FINISHED and would
+# clobber any prior KILLED / FAILED state set by the controller / worker /
+# IC handler. Instead it must clear only the local fluent active-run
+# stack via clear_local_mlflow_active_run_stack.
+#
+# Exercised in three places:
+#   1. The shared helper itself (no SetTerminated, pops the stack).
+#   2. MLflowMetricLogger.clear_context (real code path).
+#   3. The inlined experiment_utils create / end logic (replicated, same
+#      structure as _idempotent_end_run above).
+# --------------------------------------------------------------------------- #
+
+
+def test_clear_local_active_run_stack_pops_without_set_terminated():
+    """The shared helper must pop the fluent stack but never POST a status."""
+    from rapidfireai.utils.metric_mlflow_manager import (
+        clear_local_mlflow_active_run_stack,
+    )
+
+    fake_run = MagicMock()
+    fake_run.info.run_id = "popme"
+
+    fake_stack = MagicMock()
+    fake_stack.__bool__ = lambda self: True
+    fake_stack.pop = MagicMock(return_value=fake_run)
+
+    fake_monitor = MagicMock()
+    fake_monitors = {"popme": fake_monitor}
+
+    fake_last_active = MagicMock()
+    fake_run_id_env = MagicMock()
+
+    # Patch the private MLflow fluent symbols the helper reaches into.
+    import mlflow.tracking.fluent as fluent_mod
+    import mlflow.environment_variables as env_mod
+
+    with patch.object(fluent_mod, "_active_run_stack", MagicMock(get=lambda: fake_stack)), \
+         patch.object(fluent_mod, "_last_active_run_id", fake_last_active), \
+         patch.object(fluent_mod, "run_id_to_system_metrics_monitor", fake_monitors), \
+         patch.object(env_mod, "MLFLOW_RUN_ID", fake_run_id_env):
+        clear_local_mlflow_active_run_stack(logger=MagicMock())
+
+    # Stack was popped, env unset, last-active updated, monitor finished.
+    fake_stack.pop.assert_called_once()
+    fake_run_id_env.unset.assert_called_once()
+    fake_last_active.set.assert_called_once_with("popme")
+    fake_monitor.finish.assert_called_once()
+
+
+def test_clear_local_active_run_stack_swallows_internal_errors():
+    """If MLflow's private symbols shift / are missing, helper must not raise."""
+    from rapidfireai.utils.metric_mlflow_manager import (
+        clear_local_mlflow_active_run_stack,
+    )
+
+    import mlflow.tracking.fluent as fluent_mod
+
+    # Make ``_active_run_stack.get()`` blow up.
+    broken = MagicMock()
+    broken.get.side_effect = AttributeError("schema changed")
+
+    with patch.object(fluent_mod, "_active_run_stack", broken):
+        # Must not raise even when MLflow internals misbehave.
+        clear_local_mlflow_active_run_stack(logger=MagicMock())
+
+
+def test_clear_context_get_run_failure_does_not_clobber():
+    """When ``client.get_run`` raises, clear_context must NOT call
+    ``mlflow.end_run()`` -- the default FINISHED would clobber any
+    prior KILLED / FAILED status we couldn't read off the server.
+    It must instead delegate to the local-only stack-clear helper.
+    """
+    from rapidfireai.utils import metric_mlflow_manager as mm_mod
+    from rapidfireai.utils.metric_mlflow_manager import mlflow as mlflow_mod
+
+    logger = _build_mlflow_logger()
+    # Server lookup raises -- the bug scenario.
+    logger.client.get_run.side_effect = RuntimeError("server down")
+
+    active = MagicMock()
+    active.info.run_id = "blew-up-rid"
+
+    with patch.object(mlflow_mod, "active_run", return_value=active), \
+         patch.object(mlflow_mod, "end_run") as mock_end_run, \
+         patch.object(
+             mm_mod, "clear_local_mlflow_active_run_stack"
+         ) as mock_local_clear:
+        logger.clear_context()
+
+    # Critical invariant: no fluent end_run call, hence no server-side
+    # SetTerminated(FINISHED) that could clobber a prior terminal state.
+    mock_end_run.assert_not_called()
+    # Local fluent stack was cleared instead, with the logger forwarded
+    # so any internal warnings show up in the right log stream.
+    mock_local_clear.assert_called_once_with(logger.logger)
+
+
+@pytest.mark.parametrize("server_status", ["KILLED", "FAILED", "FINISHED"])
+def test_clear_context_terminal_status_still_uses_mlflow_end_run(server_status):
+    """Sanity check: when get_run succeeds and the server reports a
+    terminal state, clear_context still passes that exact status through
+    to mlflow.end_run() so set_terminated stays idempotent. (Guards the
+    refactor from accidentally routing happy-path terminal cases through
+    the local-only helper.)"""
+    from rapidfireai.utils import metric_mlflow_manager as mm_mod
+    from rapidfireai.utils.metric_mlflow_manager import mlflow as mlflow_mod
+
+    logger = _build_mlflow_logger()
+    logger.client.get_run.return_value.info.status = server_status
+
+    active = MagicMock()
+    active.info.run_id = "fine-rid"
+
+    with patch.object(mlflow_mod, "active_run", return_value=active), \
+         patch.object(mlflow_mod, "end_run") as mock_end_run, \
+         patch.object(
+             mm_mod, "clear_local_mlflow_active_run_stack"
+         ) as mock_local_clear:
+        logger.clear_context()
+
+    mock_end_run.assert_called_once_with(status=server_status)
+    mock_local_clear.assert_not_called()
+
+
+def test_clear_context_running_status_uses_default_end_run():
+    """Sanity check: when the server says the run is genuinely RUNNING,
+    clear_context defaults to mlflow.end_run() (FINISHED) -- that is
+    the correct terminal state for an explicitly-cleared healthy
+    context, and we must not regress that behaviour."""
+    from rapidfireai.utils import metric_mlflow_manager as mm_mod
+    from rapidfireai.utils.metric_mlflow_manager import mlflow as mlflow_mod
+
+    logger = _build_mlflow_logger()
+    logger.client.get_run.return_value.info.status = "RUNNING"
+
+    active = MagicMock()
+    active.info.run_id = "running-rid"
+
+    with patch.object(mlflow_mod, "active_run", return_value=active), \
+         patch.object(mlflow_mod, "end_run") as mock_end_run, \
+         patch.object(
+             mm_mod, "clear_local_mlflow_active_run_stack"
+         ) as mock_local_clear:
+        logger.clear_context()
+
+    mock_end_run.assert_called_once_with()
+    mock_local_clear.assert_not_called()
+
+
+def _idempotent_end_run_v2(metric_run_id, get_run_behavior):
+    """Updated mirror of the experiment_utils + clear_context block that
+    includes the get_run-failure branch the original ``_idempotent_end_run``
+    was missing. ``get_run_behavior`` is either a status string (the
+    server returned it) or the sentinel ``"<raise>"`` (server lookup blew
+    up). Returns a tuple ``(end_run_arg, local_clear_called)``:
+
+      end_run_arg:        the status= kwarg passed to mlflow.end_run, or
+                          ``"<no-arg>"`` for a status-less call, or
+                          ``None`` if mlflow.end_run was never called.
+      local_clear_called: True iff the local-only stack clear ran.
+    """
+    captured = {"end_run_arg": None, "local_clear_called": False}
+
+    def fake_end_run(status=None):
+        captured["end_run_arg"] = status if status is not None else "<no-arg>"
+
+    def fake_local_clear(*_args, **_kwargs):
+        captured["local_clear_called"] = True
+
+    mock_client = MagicMock()
+    if get_run_behavior == "<raise>":
+        mock_client.get_run.side_effect = RuntimeError("server down")
+    else:
+        mock_client.get_run.return_value.info.status = get_run_behavior
+
+    fake_mlflow = MagicMock()
+    fake_mlflow.end_run.side_effect = fake_end_run
+
+    if metric_run_id:
+        existing_status = None
+        get_run_failed = False
+        try:
+            existing_status = mock_client.get_run(metric_run_id).info.status
+        except Exception:
+            get_run_failed = True
+        if existing_status in ("KILLED", "FAILED", "FINISHED"):
+            fake_mlflow.end_run(status=existing_status)
+        elif get_run_failed:
+            fake_local_clear()
+        else:
+            fake_mlflow.end_run()
+    return captured["end_run_arg"], captured["local_clear_called"]
+
+
+@pytest.mark.parametrize(
+    "get_run_behavior,expected_end_arg,expected_local_clear",
+    [
+        ("KILLED", "KILLED", False),
+        ("FAILED", "FAILED", False),
+        ("FINISHED", "FINISHED", False),
+        ("RUNNING", "<no-arg>", False),
+        ("SCHEDULED", "<no-arg>", False),
+        # The regression we are pinning: get_run blew up -> no end_run,
+        # local-only clear instead. Previously this would have routed
+        # through ``else: mlflow.end_run()`` (server default FINISHED)
+        # and clobbered the prior terminal status.
+        ("<raise>", None, True),
+    ],
+)
+def test_experiment_utils_idempotent_block_handles_get_run_failure(
+    get_run_behavior, expected_end_arg, expected_local_clear
+):
+    end_arg, local_clear = _idempotent_end_run_v2("some-id", get_run_behavior)
+    assert end_arg == expected_end_arg
+    assert local_clear is expected_local_clear
+
+
+# --------------------------------------------------------------------------- #
 # Evals actor must NOT end+restart MLflow runs between shards of the same
 # pipeline (the run should stay RUNNING continuously across shards).
 # This guards against the FINISHED -> RUNNING flicker bug.

--- a/tests/test_mlflow_status_parity.py
+++ b/tests/test_mlflow_status_parity.py
@@ -539,3 +539,262 @@ def test_rf_metric_logger_fanouts_set_tag():
     # (matches the pattern in log_metric/log_param).
     mlflow_backend.set_tag.assert_called_once_with("real-id", "rapidfire.progress.current", "2")
     tensorboard_backend.set_tag.assert_called_once_with("run-name-42", "rapidfire.progress.current", "2")
+
+
+# --------------------------------------------------------------------------- #
+# restart_run: counterpart of end_run(KILLED) used by the IC resume handler.
+#
+# Stopping a run terminates its MLflow run with KILLED so the dashboard
+# matches the notebook table; resuming must flip the MLflow run back to
+# RUNNING -- otherwise the dashboard would forever show STOPPED for a
+# pipeline / fit-run that is again training. These tests pin the full
+# stack: per-backend, RFMetricLogger fan-out, evals IC handler, and fit
+# controller helper.
+# --------------------------------------------------------------------------- #
+
+
+def test_mlflow_metric_logger_restart_run_calls_update_run():
+    """``restart_run`` must POST UpdateRun(status='RUNNING') -- not set_terminated.
+
+    We use ``update_run`` (rather than ``set_terminated('RUNNING')``)
+    because the latter is semantically about terminal states even though
+    MLflow happens to accept RUNNING; the former is the explicit,
+    future-proof way to flip status.
+    """
+    logger = _build_mlflow_logger()
+    logger.client.get_run.return_value = MagicMock()  # run exists
+
+    logger.restart_run("fake-run-id")
+
+    logger.client.update_run.assert_called_once_with("fake-run-id", status="RUNNING")
+    # restart must NOT call set_terminated -- that's the kill path.
+    logger.client.set_terminated.assert_not_called()
+
+
+def test_mlflow_metric_logger_restart_run_missing_run_is_noop():
+    """Restarting a run that no longer exists should warn but not raise."""
+    logger = _build_mlflow_logger()
+    logger.client.get_run.return_value = None
+
+    logger.restart_run("missing-run-id")
+
+    logger.client.update_run.assert_not_called()
+
+
+def test_mlflow_metric_logger_restart_run_swallows_update_errors():
+    """``update_run`` failures must not propagate -- a stale dashboard cell
+    must never abort the IC op."""
+    logger = _build_mlflow_logger()
+    logger.client.get_run.return_value = MagicMock()
+    logger.client.update_run.side_effect = RuntimeError("server down")
+
+    logger.restart_run("fake-run-id")  # must not raise
+
+    logger.client.update_run.assert_called_once_with("fake-run-id", status="RUNNING")
+
+
+def test_metric_logger_default_restart_run_is_noop():
+    """Backends without a status concept (TB, Trackio) inherit a no-op default."""
+    from rapidfireai.utils.metric_logger import MetricLogger
+
+    class _Stub(MetricLogger):
+        def create_experiment(self, experiment_name):
+            return ""
+
+        def get_experiment(self, experiment_name):
+            return ""
+
+        def create_run(self, run_name):
+            return ""
+
+        def log_param(self, run_id, key, value):
+            return None
+
+        def log_metric(self, run_id, key, value, step=None):
+            return None
+
+        def get_run_metrics(self, run_id):
+            return {}
+
+        def end_run(self, run_id, status=None):
+            return None
+
+        def delete_run(self, run_id):
+            return None
+
+        def clear_context(self):
+            return None
+
+    _Stub().restart_run("run")  # must not raise
+
+
+def test_rf_metric_logger_fanouts_restart_run():
+    """RFMetricLogger.restart_run fans out: MLflow gets canonical id,
+    other backends get the human-readable run name (mirrors set_tag /
+    end_run routing)."""
+    from rapidfireai.utils.metric_logger import MetricLoggerType
+    from rapidfireai.utils.metric_rfmetric_manager import RFMetricLogger
+
+    mlflow_backend = MagicMock()
+    mlflow_backend.type = MetricLoggerType.MLFLOW
+    tensorboard_backend = MagicMock()
+    tensorboard_backend.type = MetricLoggerType.TENSORBOARD
+
+    rf = object.__new__(RFMetricLogger)
+    rf.metric_loggers = {
+        "mlflow": mlflow_backend,
+        "tensorboard": tensorboard_backend,
+    }
+    rf.logger = MagicMock()
+    rf._get_run_name = MagicMock(return_value="run-name-42")
+
+    rf.restart_run("real-id")
+
+    mlflow_backend.restart_run.assert_called_once_with("real-id")
+    tensorboard_backend.restart_run.assert_called_once_with("run-name-42")
+
+
+# --------------------------------------------------------------------------- #
+# Evals IC resume calls restart_run after re-adding to scheduler / DB.
+# --------------------------------------------------------------------------- #
+
+
+@requires_ray
+class TestEvalsInteractiveControlResume:
+    def _build_handler(self, metric_manager=None):
+        from rapidfireai.evals.scheduling.interactive_control import (
+            InteractiveControlHandler,
+        )
+
+        handler = object.__new__(InteractiveControlHandler)
+        handler.metric_manager = metric_manager
+        handler.logger = MagicMock()
+        handler.ic_logger = MagicMock()
+        handler._context_cache = {}
+        return handler
+
+    def _build_stopped_db(self, metric_run_id="resume-rid"):
+        from rapidfireai.evals.utils.constants import PipelineStatus
+
+        db = MagicMock()
+        db.get_pipeline.return_value = {
+            "shards_completed": 4,
+            "status": PipelineStatus.STOPPED.value,
+            "metric_run_id": metric_run_id,
+        }
+        return db
+
+    def test_handle_resume_restarts_mlflow_run(self):
+        mm = MagicMock()
+        handler = self._build_handler(metric_manager=mm)
+        scheduler = MagicMock()
+        db = self._build_stopped_db()
+
+        handler._handle_resume(
+            pipeline_id=12,
+            scheduler=scheduler,
+            db=db,
+            num_shards=10,
+            progress_display=None,
+        )
+
+        # Restarted with the canonical metric_run_id; no other end_run/set_terminated.
+        mm.restart_run.assert_called_once_with("resume-rid")
+        mm.end_run.assert_not_called()
+
+    def test_handle_resume_swallows_mlflow_errors(self):
+        """A flaky MLflow restart must not break the IC resume op --
+        the DB state change and scheduler re-add are what matter most."""
+        from rapidfireai.evals.utils.constants import PipelineStatus
+
+        mm = MagicMock()
+        mm.restart_run.side_effect = RuntimeError("server down")
+        handler = self._build_handler(metric_manager=mm)
+        scheduler = MagicMock()
+        db = self._build_stopped_db()
+
+        # Must not raise.
+        handler._handle_resume(
+            pipeline_id=12,
+            scheduler=scheduler,
+            db=db,
+            num_shards=10,
+            progress_display=None,
+        )
+
+        # The IC op still finished its core work even though MLflow blew up.
+        scheduler.add_pipeline.assert_called_once_with(12, 4)
+        db.set_pipeline_status.assert_called_once_with(12, PipelineStatus.ONGOING)
+
+    def test_handle_resume_no_metric_manager_is_noop(self):
+        """Without an MLflow manager (e.g. MLflow disabled) resume must
+        still succeed -- restart_run is gated on metric_manager."""
+        handler = self._build_handler(metric_manager=None)
+        scheduler = MagicMock()
+        db = self._build_stopped_db()
+
+        handler._handle_resume(
+            pipeline_id=12,
+            scheduler=scheduler,
+            db=db,
+            num_shards=10,
+            progress_display=None,
+        )
+
+        scheduler.add_pipeline.assert_called_once_with(12, 4)
+
+
+# --------------------------------------------------------------------------- #
+# Fit controller _restart_mlflow_run helper.
+#
+# Mirrors TestFitControllerFinalize -- same shape (bind unbound helper
+# onto a minimal stand-in, exercise the three paths: happy / noop /
+# swallow-errors). This is the fit-mode counterpart of the evals IC
+# resume test above.
+# --------------------------------------------------------------------------- #
+
+
+@requires_torch
+class TestFitControllerRestart:
+    def _bind(self, metric_logger, db):
+        from rapidfireai.fit.backend.controller import Controller
+
+        ctrl = _FitControllerLike(metric_logger, db, logger=MagicMock())
+        return Controller._restart_mlflow_run.__get__(ctrl, _FitControllerLike)
+
+    def test_restart_calls_metric_logger_restart_run(self):
+        ml = MagicMock()
+        db = MagicMock()
+        db.get_run.return_value = {"metric_run_id": "fit-rid"}
+        restart = self._bind(ml, db)
+
+        restart(run_id=42)
+        ml.restart_run.assert_called_once_with("fit-rid")
+        # restart must NOT terminate the run -- that's the kill path.
+        ml.end_run.assert_not_called()
+
+    def test_restart_no_metric_logger_is_noop(self):
+        """No metric_logger -> short-circuit before touching the DB."""
+        db = MagicMock()
+        db.get_run.return_value = {"metric_run_id": "fit-rid"}
+        restart = self._bind(None, db)
+        restart(run_id=42)
+        db.get_run.assert_not_called()
+
+    def test_restart_no_metric_run_id_is_noop(self):
+        ml = MagicMock()
+        db = MagicMock()
+        db.get_run.return_value = {"metric_run_id": None}
+        restart = self._bind(ml, db)
+        restart(run_id=42)
+        ml.restart_run.assert_not_called()
+
+    def test_restart_swallows_mlflow_errors(self):
+        ml = MagicMock()
+        ml.restart_run.side_effect = RuntimeError("server down")
+        db = MagicMock()
+        db.get_run.return_value = {"metric_run_id": "fit-rid"}
+        restart = self._bind(ml, db)
+
+        restart(run_id=42)  # must not raise
+        ml.restart_run.assert_called_once()

--- a/tests/test_mlflow_status_parity.py
+++ b/tests/test_mlflow_status_parity.py
@@ -1,0 +1,541 @@
+"""Unit tests for MLflow / dispatcher status parity.
+
+These cover the backend half of the two-layer plan documented at
+``mlflow_status_parity_0c21f74a.plan.md``: every terminal lifecycle
+transition (clean success, IC stop, Optuna prune, runtime / init /
+dispatch failure, worker exception, stranded-run recovery, create-run
+failure) must terminate the matching MLflow run with the right
+``RunStatus``, and the idempotency paths in ``query_actor`` and
+``experiment_utils`` must not clobber a previously-set terminal state.
+
+The tests deliberately stay narrow:
+- The shared ``MetricLogger`` abstraction and ``MLflowMetricLogger`` are
+  exercised directly with mocked ``MlflowClient``.
+- Controllers / IC handlers are exercised via their private
+  ``_finalize_mlflow_run`` helpers (evals + fit) with a mocked
+  metric_manager / metric_logger. Driving the full controller loops or
+  spinning up Ray actors is far too heavy for unit tests.
+- The idempotency logic is verified by replicating the in-tree code
+  block under unit test against a mocked client.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# These guards let the bulk of the suite run in lightweight environments
+# (CI machines without GPU stacks). The evals controller hard-imports
+# ``ray``, and the fit controller hard-imports ``torch``; when either is
+# absent, we skip the dependent classes rather than fail at collection.
+try:  # pragma: no cover - exercised by collection only
+    import ray as _ray  # noqa: F401
+
+    _HAS_RAY = True
+except Exception:
+    _HAS_RAY = False
+try:  # pragma: no cover
+    import torch as _torch  # noqa: F401
+
+    _HAS_TORCH = True
+except Exception:
+    _HAS_TORCH = False
+
+requires_ray = pytest.mark.skipif(not _HAS_RAY, reason="ray not installed")
+requires_torch = pytest.mark.skipif(not _HAS_TORCH, reason="torch not installed")
+
+
+# --------------------------------------------------------------------------- #
+# MLflowMetricLogger.end_run forwards status to set_terminated.
+# --------------------------------------------------------------------------- #
+
+
+def _build_mlflow_logger():
+    """Build an MLflowMetricLogger with a mocked client (no MLflow server).
+
+    We bypass ``__init__`` (which talks to a live MLflow tracking server) and
+    inject the bare minimum the tested methods need.
+    """
+    from rapidfireai.utils.metric_logger import MetricLoggerType
+    from rapidfireai.utils.metric_mlflow_manager import MLflowMetricLogger
+
+    logger = object.__new__(MLflowMetricLogger)
+    logger.type = MetricLoggerType.MLFLOW
+    logger.client = MagicMock()
+    logger.logger = MagicMock()
+    return logger
+
+
+@pytest.mark.parametrize(
+    "status",
+    ["FINISHED", "FAILED", "KILLED"],
+)
+def test_mlflow_metric_logger_end_run_forwards_status(status):
+    """end_run(status=X) must call set_terminated(run_id, status=X)."""
+    from rapidfireai.utils.metric_mlflow_manager import mlflow as mlflow_mod
+
+    logger = _build_mlflow_logger()
+    logger.client.get_run.return_value = MagicMock()  # run exists
+
+    with patch.object(mlflow_mod, "active_run", return_value=None):
+        logger.end_run("fake-run-id", status=status)
+
+    logger.client.set_terminated.assert_called_once_with("fake-run-id", status=status)
+
+
+def test_mlflow_metric_logger_end_run_default_preserves_behaviour():
+    """end_run() with no status falls back to the server default (FINISHED)."""
+    from rapidfireai.utils.metric_mlflow_manager import mlflow as mlflow_mod
+
+    logger = _build_mlflow_logger()
+    logger.client.get_run.return_value = MagicMock()
+
+    with patch.object(mlflow_mod, "active_run", return_value=None):
+        logger.end_run("fake-run-id")
+
+    logger.client.set_terminated.assert_called_once_with("fake-run-id")
+
+
+def test_mlflow_metric_logger_end_run_active_run_uses_status():
+    """When the run is the local fluent-API active run, mlflow.end_run(status=X) is also called."""
+    from rapidfireai.utils.metric_mlflow_manager import mlflow as mlflow_mod
+
+    logger = _build_mlflow_logger()
+    logger.client.get_run.return_value = MagicMock()
+
+    active = MagicMock()
+    active.info.run_id = "fake-run-id"
+
+    with patch.object(mlflow_mod, "active_run", return_value=active), patch.object(
+        mlflow_mod, "end_run"
+    ) as mock_end_run:
+        logger.end_run("fake-run-id", status="KILLED")
+
+    logger.client.set_terminated.assert_called_once_with("fake-run-id", status="KILLED")
+    mock_end_run.assert_called_once_with(status="KILLED")
+
+
+# --------------------------------------------------------------------------- #
+# Dispatcher -> MLflow status mapping helper.
+# --------------------------------------------------------------------------- #
+
+
+class TestDispatcherStatusMapping:
+    def test_completed_maps_to_finished(self):
+        from rapidfireai.utils.metric_mlflow_manager import dispatcher_status_to_mlflow
+
+        assert dispatcher_status_to_mlflow("completed") == "FINISHED"
+
+    def test_stopped_maps_to_killed(self):
+        from rapidfireai.utils.metric_mlflow_manager import dispatcher_status_to_mlflow
+
+        assert dispatcher_status_to_mlflow("stopped") == "KILLED"
+
+    def test_failed_maps_to_failed(self):
+        from rapidfireai.utils.metric_mlflow_manager import dispatcher_status_to_mlflow
+
+        assert dispatcher_status_to_mlflow("failed") == "FAILED"
+
+    def test_uppercase_input(self):
+        from rapidfireai.utils.metric_mlflow_manager import dispatcher_status_to_mlflow
+
+        assert dispatcher_status_to_mlflow("COMPLETED") == "FINISHED"
+
+    def test_unknown_returns_none(self):
+        from rapidfireai.utils.metric_mlflow_manager import dispatcher_status_to_mlflow
+
+        assert dispatcher_status_to_mlflow("new") is None
+        assert dispatcher_status_to_mlflow("ongoing") is None
+        assert dispatcher_status_to_mlflow(None) is None
+
+    def test_enum_input(self):
+        from rapidfireai.utils.metric_mlflow_manager import dispatcher_status_to_mlflow
+        from rapidfireai.evals.utils.constants import PipelineStatus
+
+        assert dispatcher_status_to_mlflow(PipelineStatus.COMPLETED) == "FINISHED"
+        assert dispatcher_status_to_mlflow(PipelineStatus.STOPPED) == "KILLED"
+        assert dispatcher_status_to_mlflow(PipelineStatus.FAILED) == "FAILED"
+
+
+# --------------------------------------------------------------------------- #
+# Evals controller _finalize_mlflow_run helper.
+# --------------------------------------------------------------------------- #
+
+
+class _EvalsControllerLike:
+    """Minimal stand-in that lets us exercise the bound helper without
+    paying the full Controller __init__ cost (which expects a real
+    experiment dir, Ray, etc.).
+    """
+
+    def __init__(self, metric_manager, logger):
+        self.metric_manager = metric_manager
+        self.logger = logger
+
+
+@requires_ray
+class TestEvalsControllerFinalize:
+    def _bind(self, metric_manager):
+        from rapidfireai.evals.scheduling.controller import Controller
+
+        ctrl = _EvalsControllerLike(metric_manager, logger=MagicMock())
+        # Bind the unbound method onto our stand-in.
+        return Controller._finalize_mlflow_run.__get__(ctrl, _EvalsControllerLike)
+
+    def _db_with_metric_run_id(self, metric_run_id):
+        db = MagicMock()
+        db.get_pipeline.return_value = {"metric_run_id": metric_run_id}
+        return db
+
+    @pytest.mark.parametrize("mlflow_status", ["KILLED", "FAILED", "FINISHED"])
+    def test_finalize_passes_status_through(self, mlflow_status):
+        mm = MagicMock()
+        finalize = self._bind(mm)
+        db = self._db_with_metric_run_id("evals-rid")
+
+        finalize(db, pipeline_id=7, mlflow_status=mlflow_status)
+
+        mm.end_run.assert_called_once_with("evals-rid", status=mlflow_status)
+
+    def test_finalize_no_metric_manager_is_noop(self):
+        finalize = self._bind(None)
+        db = self._db_with_metric_run_id("evals-rid")
+        finalize(db, pipeline_id=7, mlflow_status="FAILED")  # must not raise
+
+    def test_finalize_no_metric_run_id_is_noop(self):
+        mm = MagicMock()
+        finalize = self._bind(mm)
+        db = MagicMock()
+        db.get_pipeline.return_value = {"metric_run_id": None}
+
+        finalize(db, pipeline_id=7, mlflow_status="FAILED")
+        mm.end_run.assert_not_called()
+
+    def test_finalize_swallows_mlflow_errors(self):
+        mm = MagicMock()
+        mm.end_run.side_effect = RuntimeError("server down")
+        finalize = self._bind(mm)
+        db = self._db_with_metric_run_id("evals-rid")
+
+        # Must not raise: MLflow trouble cannot fail the pipeline.
+        finalize(db, pipeline_id=7, mlflow_status="FAILED")
+        mm.end_run.assert_called_once()
+
+
+# --------------------------------------------------------------------------- #
+# Evals IC stop calls end_run(KILLED).
+# --------------------------------------------------------------------------- #
+
+
+@requires_ray
+class TestEvalsInteractiveControlStop:
+    def test_handle_stop_terminates_mlflow_with_killed(self):
+        from rapidfireai.evals.scheduling.interactive_control import (
+            InteractiveControlHandler,
+        )
+
+        # Build the handler with a mocked metric_manager. We use object.__new__
+        # so we don't pay the constructor cost (logger setup, etc.).
+        handler = object.__new__(InteractiveControlHandler)
+        handler.metric_manager = MagicMock()
+        handler.logger = MagicMock()
+        handler.ic_logger = MagicMock()
+        handler._context_cache = {}
+
+        scheduler = MagicMock()
+        scheduler.remove_pipeline.return_value = 3
+
+        db = MagicMock()
+        db.get_pipeline.return_value = {"metric_run_id": "stop-rid"}
+
+        handler._handle_stop(
+            pipeline_id=12,
+            scheduler=scheduler,
+            db=db,
+            progress_display=None,
+        )
+
+        handler.metric_manager.end_run.assert_called_once_with(
+            "stop-rid", status="KILLED"
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Fit controller _finalize_mlflow_run helper.
+# --------------------------------------------------------------------------- #
+
+
+class _FitControllerLike:
+    def __init__(self, metric_logger, db, logger):
+        self.metric_logger = metric_logger
+        self.db = db
+        self.logger = logger
+
+
+@requires_torch
+class TestFitControllerFinalize:
+    def _bind(self, metric_logger, db):
+        from rapidfireai.fit.backend.controller import Controller
+
+        ctrl = _FitControllerLike(metric_logger, db, logger=MagicMock())
+        return Controller._finalize_mlflow_run.__get__(ctrl, _FitControllerLike)
+
+    @pytest.mark.parametrize("mlflow_status", ["KILLED", "FAILED", "FINISHED"])
+    def test_finalize_passes_status_through(self, mlflow_status):
+        ml = MagicMock()
+        db = MagicMock()
+        db.get_run.return_value = {"metric_run_id": "fit-rid"}
+        finalize = self._bind(ml, db)
+
+        finalize(run_id=42, mlflow_status=mlflow_status)
+        ml.end_run.assert_called_once_with("fit-rid", status=mlflow_status)
+
+    def test_finalize_no_metric_logger_is_noop(self):
+        db = MagicMock()
+        db.get_run.return_value = {"metric_run_id": "fit-rid"}
+        finalize = self._bind(None, db)
+        finalize(run_id=42, mlflow_status="FAILED")
+        db.get_run.assert_not_called()
+
+    def test_finalize_no_metric_run_id_is_noop(self):
+        ml = MagicMock()
+        db = MagicMock()
+        db.get_run.return_value = {"metric_run_id": None}
+        finalize = self._bind(ml, db)
+        finalize(run_id=42, mlflow_status="FAILED")
+        ml.end_run.assert_not_called()
+
+    def test_finalize_swallows_mlflow_errors(self):
+        ml = MagicMock()
+        ml.end_run.side_effect = RuntimeError("server down")
+        db = MagicMock()
+        db.get_run.return_value = {"metric_run_id": "fit-rid"}
+        finalize = self._bind(ml, db)
+
+        finalize(run_id=42, mlflow_status="FAILED")  # must not raise
+        ml.end_run.assert_called_once()
+
+
+# --------------------------------------------------------------------------- #
+# Idempotency: actor / experiment_utils mlflow.end_run() preserves terminal state.
+#
+# These tests replicate the in-tree code block (we can't easily invoke the
+# actor's full process_query_request body in unit tests) and verify the
+# logic does the right thing for each server-side status.
+# --------------------------------------------------------------------------- #
+
+
+def _idempotent_end_run(metric_run_id, server_status):
+    """Mirror the idempotency snippet shared by query_actor and
+    experiment_utils. Returns the status arg passed to mlflow.end_run,
+    or ``"<no-arg>"`` when called with no kwargs (server default).
+    """
+    captured = {"called_with": None}
+
+    def fake_end_run(status=None):
+        captured["called_with"] = status if status is not None else "<no-arg>"
+
+    mock_client = MagicMock()
+    mock_client.get_run.return_value.info.status = server_status
+
+    fake_mlflow = MagicMock()
+    fake_mlflow.end_run.side_effect = fake_end_run
+
+    # Inlined logic mirroring the actor / experiment_utils path.
+    if metric_run_id:
+        existing_status = None
+        try:
+            existing_status = mock_client.get_run(metric_run_id).info.status
+        except Exception:
+            pass
+        if existing_status in ("KILLED", "FAILED", "FINISHED"):
+            fake_mlflow.end_run(status=existing_status)
+        else:
+            fake_mlflow.end_run()
+    return captured["called_with"]
+
+
+@pytest.mark.parametrize(
+    "server_status,expected",
+    [
+        ("KILLED", "KILLED"),
+        ("FAILED", "FAILED"),
+        ("FINISHED", "FINISHED"),
+        ("RUNNING", "<no-arg>"),
+        ("SCHEDULED", "<no-arg>"),
+    ],
+)
+def test_idempotent_end_run_preserves_terminal_state(server_status, expected):
+    assert _idempotent_end_run("some-id", server_status) == expected
+
+
+# --------------------------------------------------------------------------- #
+# Evals actor must NOT end+restart MLflow runs between shards of the same
+# pipeline (the run should stay RUNNING continuously across shards).
+# This guards against the FINISHED -> RUNNING flicker bug.
+# --------------------------------------------------------------------------- #
+
+
+def _actor_request_block(self_metric_run_id, incoming_metric_run_id):
+    """Mirror the actor's pipeline-transition logic for unit testing.
+
+    Records every observable side-effect the block would have:
+      ``("clear_local",)`` -- pop local active-run stack, no server call
+      ``("start_run", run_id)`` -- mlflow.start_run(run_id=...)
+      ``("server_end_run", status)`` -- set_terminated on server (forbidden!)
+
+    The actor MUST NEVER produce a ``server_end_run`` event when
+    transitioning between pipelines: the controller is the single
+    authority on terminal status. This list captures that invariant.
+    """
+    actions = []
+
+    same_pipeline_next_shard = (
+        self_metric_run_id is not None and self_metric_run_id == incoming_metric_run_id
+    )
+    is_mlflow_enabled = True
+
+    if self_metric_run_id and is_mlflow_enabled and not same_pipeline_next_shard:
+        # NB: explicitly local-only -- no SetTerminated on the server.
+        actions.append(("clear_local",))
+
+    if incoming_metric_run_id and is_mlflow_enabled and not same_pipeline_next_shard:
+        actions.append(("start_run", incoming_metric_run_id))
+
+    return actions
+
+
+def test_actor_same_pipeline_next_shard_does_not_touch_mlflow():
+    """Actor reused for the same pipeline: MLflow run stays RUNNING; no calls."""
+    assert _actor_request_block(
+        self_metric_run_id="run-a", incoming_metric_run_id="run-a"
+    ) == []
+
+
+def test_actor_different_pipeline_clears_local_and_starts_new():
+    """Actor switched to a different pipeline: clear LOCAL state only and start new.
+
+    Critically, no ``server_end_run`` event -- if we hit set_terminated on
+    the server, the previous pipeline (which may still have shards in flight
+    on other actors) would prematurely show as COMPLETED on the dashboard.
+    """
+    actions = _actor_request_block(
+        self_metric_run_id="run-a", incoming_metric_run_id="run-b"
+    )
+    assert actions == [("clear_local",), ("start_run", "run-b")]
+    # Defensive check: the forbidden side-effect must never appear.
+    assert not any(a[0] == "server_end_run" for a in actions)
+
+
+def test_actor_first_pipeline_only_starts():
+    """First pipeline on a fresh actor: nothing to clear, just start the new one."""
+    assert _actor_request_block(
+        self_metric_run_id=None, incoming_metric_run_id="run-a"
+    ) == [("start_run", "run-a")]
+
+
+# --------------------------------------------------------------------------- #
+# RFMetricLogger forwards status to per-backend end_run.
+# --------------------------------------------------------------------------- #
+
+
+def test_rf_metric_logger_forwards_status_to_backends():
+    from rapidfireai.utils.metric_logger import MetricLoggerType
+    from rapidfireai.utils.metric_rfmetric_manager import RFMetricLogger
+
+    mlflow_backend = MagicMock()
+    mlflow_backend.type = MetricLoggerType.MLFLOW
+    tensorboard_backend = MagicMock()
+    tensorboard_backend.type = MetricLoggerType.TENSORBOARD
+
+    # Build an RFMetricLogger but inject its dependencies directly.
+    rf = object.__new__(RFMetricLogger)
+    rf.metric_loggers = {
+        "mlflow": mlflow_backend,
+        "tensorboard": tensorboard_backend,
+    }
+    rf.logger = MagicMock()
+    rf._get_run_name = MagicMock(return_value="my-run")
+
+    rf.end_run("real-run-id", status="KILLED")
+
+    mlflow_backend.end_run.assert_called_once_with("real-run-id", status="KILLED")
+    tensorboard_backend.end_run.assert_called_once_with("my-run", status="KILLED")
+
+
+# --------------------------------------------------------------------------- #
+# set_tag: progress tags emitted by the evals controller for the Shards
+# column on the dashboard. MLflow must receive the tag; TB/Trackio use
+# the no-op default in MetricLogger.
+# --------------------------------------------------------------------------- #
+
+
+def test_mlflow_metric_logger_set_tag_forwards_to_client():
+    """``MLflowMetricLogger.set_tag`` must call ``client.set_tag`` with stringified value."""
+    logger = _build_mlflow_logger()
+    logger.set_tag("run-xyz", "rapidfire.progress.current", 3)
+    logger.client.set_tag.assert_called_once_with("run-xyz", "rapidfire.progress.current", "3")
+
+
+def test_metric_logger_default_set_tag_is_noop():
+    """Backends without a real implementation should silently accept set_tag."""
+    from rapidfireai.utils.metric_logger import MetricLogger
+
+    # Subclass MetricLogger and provide stubs for the abstract methods so
+    # we can instantiate it. The whole point of this test is that the
+    # default ``set_tag`` doesn't raise -- it's a no-op for backends that
+    # don't have a native tag concept.
+    class _Stub(MetricLogger):
+        def create_experiment(self, experiment_name):
+            return ""
+
+        def get_experiment(self, experiment_name):
+            return ""
+
+        def create_run(self, run_name):
+            return ""
+
+        def log_param(self, run_id, key, value):
+            return None
+
+        def log_metric(self, run_id, key, value, step=None):
+            return None
+
+        def get_run_metrics(self, run_id):
+            return {}
+
+        def end_run(self, run_id, status=None):
+            return None
+
+        def delete_run(self, run_id):
+            return None
+
+        def clear_context(self):
+            return None
+
+    _Stub().set_tag("run", "key", "value")  # must not raise
+
+
+def test_rf_metric_logger_fanouts_set_tag():
+    """RFMetricLogger.set_tag fans out to every configured backend."""
+    from rapidfireai.utils.metric_logger import MetricLoggerType
+    from rapidfireai.utils.metric_rfmetric_manager import RFMetricLogger
+
+    mlflow_backend = MagicMock()
+    mlflow_backend.type = MetricLoggerType.MLFLOW
+    tensorboard_backend = MagicMock()
+    tensorboard_backend.type = MetricLoggerType.TENSORBOARD
+
+    rf = object.__new__(RFMetricLogger)
+    rf.metric_loggers = {
+        "mlflow": mlflow_backend,
+        "tensorboard": tensorboard_backend,
+    }
+    rf.logger = MagicMock()
+    rf._get_run_name = MagicMock(return_value="run-name-42")
+
+    rf.set_tag("real-id", "rapidfire.progress.current", "2")
+
+    # MLflow gets the canonical run_id; TB/Trackio get the human name
+    # (matches the pattern in log_metric/log_param).
+    mlflow_backend.set_tag.assert_called_once_with("real-id", "rapidfire.progress.current", "2")
+    tensorboard_backend.set_tag.assert_called_once_with("run-name-42", "rapidfire.progress.current", "2")


### PR DESCRIPTION
## Changes

Closes the long-standing gap between dispatcher status (the source of truth shown in the notebook progress table) and MLflow status (shown on the dashboard) for both `run_fit()` and `run_evals()`. Before this PR, terminal lifecycle events (clean success, IC-stop, Optuna prune, runtime / init / dispatch failure, worker exception, stranded-run recovery, create-run failure) frequently left MLflow runs in the default `RUNNING`→`FINISHED` state, so the dashboard would disagree with the notebook table (e.g., a run shown as `STOPPED` in the notebook would render `Running` or `Finished` on the dashboard). Several `mlflow.end_run()` paths (`experiment_utils.create_experiment` / `end_experiment`, `MLflowMetricLogger.clear_context`, `query_actor` pipeline switch) would also clobber an already-terminal status with `FINISHED`.

The fix has two layers:

- **Backend.** A single `DISPATCHER_TO_MLFLOW_STATUS` mapping in `metric_mlflow_manager` (`COMPLETED→FINISHED`, `STOPPED→KILLED`, `FAILED→FAILED`). `MetricLogger.end_run()` and every backend implementation (MLflow / RFMetric / TensorBoard / Trackio) now accept an optional `status` kwarg. New `_finalize_mlflow_run()` helpers on the fit and evals Controllers terminate the matching MLflow run with the right status at every terminal transition; the fit worker mirrors the same on training exceptions. The stranded-run recovery path in `rf_db.py` now also terminates orphaned MLflow runs as `FAILED` so they don't sit `RUNNING` forever after a crash. `experiment_utils` and `clear_context()` read existing server-side status before ending so the fluent API is idempotent. `query_actor` now clears only its *local* per-actor fluent-API run stack between pipelines instead of POSTing `SetTerminated(FINISHED)`, which previously marked still-in-flight pipelines as `FINISHED` while other actors were still processing them.
- **Frontend.** New `RunStatusCellRenderer` plus a new pinned-left `Status` column on the experiment runs table that relabels MLflow's vocabulary (`FINISHED` / `KILLED` / `RUNNING` / `SCHEDULED`) to the dispatcher's (`COMPLETED` / `STOPPED` / `ONGOING` / `NEW`). `RunViewStatusBox` on the run detail page does the same relabel and gains amber tag colors for `KILLED`. `RunStatusIcon` splits `KILLED` out from `FAILED` and renders it with a `StopCircleIcon` in warning amber (an intentional halt is not an error). The status icon prefix is removed from `DateCellRenderer` since `Status` now owns that signal. `en.json` is updated for the new defaults.

While in this area, also adds a **`Shards` column** (`RunShardsCellRenderer`) sourced from new mutable MLflow tags `rapidfire.progress.current` / `rapidfire.progress.total`. The evals controller seeds these tags at pipeline registration, updates `current` after every shard, and re-seeds for IC-clone / Optuna-replacement pipelines; the IC handler seeds them when cloning. A second commit (`shards display`) wires the same pattern into the fit controller via a new `_set_progress_tags()` helper that seeds in `_create_models`, advances on each chunk completion, resets to `0` at epoch rollover, and re-seeds when IC Ops resume / re-add a run.

New `tests/test_mlflow_status_parity.py` (541 lines) covers every terminal transition, the `end_run(status=...)` forwarding across backends, the `set_tag` fan-out, the idempotency paths, and the `dispatcher_status_to_mlflow` mapping, with `ray` / `torch` import guards so the suite still collects on lightweight CI machines.

**Breaking / unusual behavior to flag for reviewers:**
- `MetricLogger.end_run()` and its three backend implementations now take an optional `status` kwarg. Default (`None`) preserves prior behavior, so existing external callers keep working — but custom subclasses of `MetricLogger` will need to widen their `end_run` signature.
- Dashboard labels have changed: `Finished` → `COMPLETED`, `Killed` → `STOPPED`, `Running` → `ONGOING`, `Scheduled` → `NEW`. Anyone depending on the old strings in screenshots / docs / e2e tests will need to update.
- `KILLED` runs now render in amber/warning rather than red/error. Visually distinct from `FAILED`.

## Changelog Content

### Additions
- New `Status` column on the experiment runs table (pinned left after Run Name) showing dispatcher-vocabulary lifecycle state with per-state color.
- New `Shards` column showing live shard / chunk progress (`current/total`) for both evals (per-shard) and fit (per-chunk-per-epoch) runs.
- New mutable MLflow tags `rapidfire.progress.current` and `rapidfire.progress.total` emitted by both the fit and evals controllers; `MetricLogger.set_tag()` API across all backends.
- Stranded-run recovery (`rf_db.py` `reset_all_tables` path) now also terminates orphaned MLflow runs as `FAILED`.
- New unit-test suite `tests/test_mlflow_status_parity.py` covering every status-parity transition, idempotency path, and the new helpers.

### Changes
- Dashboard relabels MLflow's native enum to the dispatcher's vocabulary across the experiment runs table and the run detail page: `Finished` → `COMPLETED`, `Killed` → `STOPPED`, `Running` → `ONGOING`, `Scheduled` → `NEW`.
- `KILLED` (dispatcher `STOPPED`) now renders with a `StopCircleIcon` in warning amber instead of the red error icon used for `FAILED` — an intentional halt is no longer visually conflated with a failure.
- `DateCellRenderer` no longer prefixes the timestamp with the run-status icon (the new `Status` column owns that signal).
- `experiment_utils.create_experiment` / `end_experiment` and `MLflowMetricLogger.clear_context()` now read the active run's server-side status before calling `mlflow.end_run()` so a terminal state already set by the controller / worker / IC handler is preserved instead of being overwritten with `FINISHED`.

### Fixes
- Dashboard MLflow status now matches the dispatcher status shown in the notebook progress table across all terminal transitions in both `run_fit()` and `run_evals()`: clean completion, IC-stop, Optuna prune, worker exception, runtime / init / dispatch failure, create-run failure, and stranded-run recovery after a crash.
- Reused query actors no longer mark a still-running pipeline as `FINISHED` on the MLflow server when switching to the next pipeline.
- Orphaned `ONGOING` / `NEW` runs left over from a crashed experiment no longer remain stuck as `RUNNING` in MLflow after recovery.
- Cloned pipelines (IC clone) and Optuna replacement runs now render shard progress in the `Shards` column instead of `-`.
- Failed run-creation paths now record the MLflow run as `FAILED` instead of letting it default to `FINISHED`.

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change manually
- [x] I have tested this change in the following environments:
  - [x] Local development
  - [ ] Docker environment
  - [ ] Other: _______________

## Screenshots (if applicable)
<img width="1728" height="951" alt="Screenshot 2026-06-18 at 4 39 19 PM" src="https://github.com/user-attachments/assets/75e15319-368a-44c4-a388-66d9e87df0ad" />
<img width="1728" height="869" alt="Screenshot 2026-06-18 at 3 36 02 PM" src="https://github.com/user-attachments/assets/7e06c194-c109-455b-88f7-7464fbac5f71" />
<img width="1728" height="869" alt="Screenshot 2026-06-18 at 3 34 21 PM" src="https://github.com/user-attachments/assets/8ce0b910-9002-4503-8a89-048481b4b8c5" />

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Performance Impact
If this PR affects performance, describe the impact and any optimizations made.

## Related Issues
Fixes #(issue number)
Closes #(issue number)
Related to #(issue number)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches MLflow termination across evals/fit controllers, actors, workers, and DB recovery—incorrect status could still mislead the dashboard, but changes are centralized with best-effort error handling and a large dedicated test suite.
> 
> **Overview**
> Aligns **MLflow run lifecycle** with the dispatcher/notebook table for both **evals** and **fit**, and updates the experiment UI so status and shard progress match what users see in the notebook.
> 
> **Backend:** Central mapping (`COMPLETED→FINISHED`, `STOPPED→KILLED`, `FAILED→FAILED`) drives explicit `end_run(status=…)` from controllers, workers, IC stop/prune/resume, and stranded-run recovery. Controllers own terminal status; reused query actors only clear the **local** MLflow stack when switching pipelines (no premature `FINISHED` on still-running work). Phase 8 no longer overwrites **STOPPED** pipelines to **COMPLETED** or re-ends KILLED runs as FINISHED. New **`rapidfire.progress.current` / `total`** MLflow tags power live shard/chunk progress; **`set_tag`** and **`restart_run`** extend the metric logger API. **`clear_local_mlflow_active_run_stack`** and idempotent `clear_context` / experiment start-end avoid clobbering terminal server status when `get_run` fails.
> 
> **Frontend:** Pinned **Status** and **Shards** columns; MLflow enums relabeled to dispatcher words (**COMPLETED**, **STOPPED**, **ONGOING**, **NEW**); **KILLED** shown as amber stop (not red error). Status icon removed from the Created column.
> 
> **Tests:** `tests/test_mlflow_status_parity.py` covers status forwarding, IC resume, actor transitions, and idempotency paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 751e6f144f85dd46e9e7a75b299985e0b448793d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->