### PR TITLE
Fix numpy version to 2.0.1 for Colab/Fit

### DIFF
--- a/rapidfireai/cli.py
+++ b/rapidfireai/cli.py
@@ -489,9 +489,9 @@ def install_packages(
             packages.append({"package": "cupy-cuda13x==14.0.1", "extra_args": ["--upgrade"]})
         packages.append({"package": "numpy==2.0.1", "extra_args": ["--upgrade"]})
 
-    # if ColabConfig.ON_COLAB:
-    #     packages.append({"package": "cupy-cuda12x==14.0.1", "extra_args": ["--upgrade"]})
-    #     packages.append({"package": "numpy==2.0.1", "extra_args": ["--upgrade"]})
+    if not evals:
+        if ColabConfig.ON_COLAB:
+            packages.append({"package": "numpy==2.0.1", "extra_args": ["--upgrade"]})
 
     for package_info in packages:
         try:


### PR DESCRIPTION
## Changes
- Downgrade Numpy to 2.0.1 on Colab for SFT notebook issue with datasets

## Changelog Content
### Fixes
- Downgrade Numpy to 2.0.1 on Colab for SFT notebook issue with datasets


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Colab-only dependency pin during `init` fit mode; no auth, runtime, or non-Colab install path changes.
> 
> **Overview**
> **Colab fit init** (`rapidfireai init --train`) now upgrades **`numpy==2.0.1`** after requirements install, mirroring the existing evals pin and avoiding SFT / `datasets` breakage from newer NumPy.
> 
> Removes dead commented Colab `cupy`/`numpy` install blocks; does not change non-Colab or evals package logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12aff6c7d2b9413de3c06f5d39de9590f4cfea5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->