### PR TITLE
Add the AI-agent setup guide and make it discoverable (docs/AGENTS.md, README, PyPI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,17 @@ Rapid experimentation for easier, faster, and more impactful AI customization.
 Built for agentic RAG, context engineering, fine-tuning, and post-training of LLMs and other DL models. 
 Delivers 16-24x higher throughput without extra resources.
 
+<details>
+<summary><strong>🤖 AI coding agent helping a user install or set up rapidfireai? Read first</strong></summary>
+
+If you are an AI coding agent (Claude Code, Cursor, Codex, GitHub Copilot, Windsurf, Aider, Junie, ...) helping a user install or set up `rapidfireai`, read **[`docs/AGENTS.md`](https://github.com/RapidFireAI/rapidfireai/blob/main/docs/AGENTS.md)** ([raw](https://raw.githubusercontent.com/RapidFireAI/rapidfireai/main/docs/AGENTS.md)) first. It is the operational install/setup/troubleshooting guide with a workflow decision tree and safety rules.
+
+Quick decision: **RAG / context engineering** → `rapidfireai init` + `Experiment(..., mode="evals")`. **Fine-tuning / post-training (SFT/DPO/GRPO)** → `rapidfireai init --train` + `Experiment(..., mode="fit")`.
+
+> **Note for agents working *on* rapidfireai itself (contributors)**: this disclosure is for *end-user* assistance. For repo-internal architecture, build, and contributor flow, see root [`AGENTS.md`](https://github.com/RapidFireAI/rapidfireai/blob/main/AGENTS.md) (canonical for all AI coding agents) and [`CONTRIBUTING.md`](https://github.com/RapidFireAI/rapidfireai/blob/main/CONTRIBUTING.md).
+
+</details>
+
 ## Overview
 
 RapidFire AI is a new experiment execution framework that transforms your AI customization experimentation from slow, sequential processes into rapid, intelligent workflows with hyperparallelized execution, dynamic real-time experiment control, and automatic system optimization.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,143 @@
+# RapidFire AI — Agent Install & Setup Guide
+
+Operational instructions for **AI coding agents** (Claude Code, Cursor, Codex, GitHub Copilot, Windsurf, Aider, Junie, and similar) that are helping an end user install, configure, and run the `rapidfireai` Python package.
+
+This file is **not** for rapidfireai contributors. If you are working *on* rapidfireai itself, stop and read the repo's root [`AGENTS.md`](https://github.com/RapidFireAI/rapidfireai/blob/main/AGENTS.md) and [`CONTRIBUTING.md`](https://github.com/RapidFireAI/rapidfireai/blob/main/CONTRIBUTING.md) instead.
+
+## 1. Audience and authority
+
+### Source-of-truth rule (read first)
+
+This guide does **not** restate version-specific install commands, package versions, port numbers, or known-issue workarounds. Those live in the canonical [`README.md`](https://github.com/RapidFireAI/rapidfireai/blob/main/README.md) (sections **§Prerequisites**, **§Install and Get Started**, **§Troubleshooting**) and in the codebase, and they change between releases. **Whenever this guide and the README disagree on a specific command or version, trust the README.**
+
+What this guide *does* provide that the README does not:
+
+- A workflow decision tree (RAG vs fine-tuning vs post-training; OpenAI vs self-hosted; lite vs full).
+- Trainer-type taxonomy for fine-tuning (`SFT` / `DPO` / `GRPO`).
+- Safety rules for handling user secrets, GPU assumptions, and gated model access.
+
+### Version awareness
+
+After installing, run `rapidfireai --version` to see the live version. This guide assumes the **0.15+ API surface**. If the installed package differs significantly, prefer the canonical docs at <https://oss-docs.rapidfire.ai>.
+
+Canonical raw URL of this file (for `WebFetch`): <https://raw.githubusercontent.com/RapidFireAI/rapidfireai/main/docs/AGENTS.md>.
+
+---
+
+## 2. Workflow decision tree
+
+Pick a branch **before** running any install commands — the two workflows install different dependency sets that are not interchangeable.
+
+- **User wants RAG / context-engineering evaluation** → use `Experiment(..., mode="evals")` and run the default `rapidfireai init` (evals dependencies are the default).
+  - Generation/embedding via **OpenAI / Azure OpenAI / Anthropic** APIs → use `RFAPIModelConfig`. **No GPU strictly required** — viable on CPU-only machines.
+  - Generation via **self-hosted Hugging Face** models → use `RFvLLMModelConfig`. **GPU required.** May require Hugging Face authentication for gated models.
+- **User wants fine-tuning or post-training** → use `Experiment(..., mode="fit")` and run `rapidfireai init --train` (the training-only opt-in).
+  - **SFT** (supervised fine-tuning, e.g., chat/QA tuning) → `trainer_type="SFT"`.
+  - **DPO** (direct preference optimization, alignment from `chosen`/`rejected` pairs) → `trainer_type="DPO"`.
+  - **GRPO** (group relative policy optimization, RL with reward functions) → `trainer_type="GRPO"`.
+
+### Environment selectors
+
+- **Remote / cloud machine** → an SSH port-forward is required to view the dashboard locally. The set of ports differs by workflow (smaller for fit, larger for evals because Jupyter and MLflow are also exposed). The current port set and the exact `ssh` command are in the README §Install — read them from there, do not memorize.
+- **GPU issues** (CUDA absent, OOM, driver mismatch) → run `rapidfireai doctor` and act on its output. For OOM, switch the user to a *lite* tutorial variant (see §6).
+- **Hugging Face permission issues** → confirm the user has run the README's HF auth step and has been granted access on the gated model's HF page. If access is blocked, suggest an open-license substitute (TinyLlama, Qwen-0.5B/3B) where licensing permits.
+
+The full install command sequence and the exact set of port numbers are in the README, the authoritative install reference.
+
+---
+
+## 3. Setup order
+
+Run the steps in the order below. The **commands** are in the README; the **decisions, ordering, and pitfalls** below are what you should add on top.
+
+1. **Verify the user's environment matches README §Prerequisites *before* installing.** At minimum: (a) check the Python version (`python --version`); (b) for any **GPU-required workflow** — all fine-tuning (SFT/DPO/GRPO) and self-hosted RAG/eval — confirm GPU presence and CUDA via `nvidia-smi`. If GPU is required but absent, **stop and redirect**: the API-based RAG/eval workflow (with `RFAPIModelConfig`) does not need a GPU and is the only viable path on CPU-only hosts. Do not paper over a Python or GPU mismatch by trying to "fix" the system; surface the requirement to the user.
+2. **Create and activate a virtual environment** *before* `pip install`. Do not assume the user is already in one.
+3. **Install** the package as documented in README §Install. The exact `pip install` line lives there.
+4. **Verify** the install: `rapidfireai --version` should return a version string. If it does not, stop and diagnose; do not proceed.
+5. **Hugging Face authentication** *before* `init`/`start`, but only if the user's chosen workflow needs it (gated models, or any HF model download for self-hosted RAG/eval, or any fine-tuning). The README gives the auth command. **You must not invent a token; ask the user.**
+6. **Apply current workarounds** that the README's install section calls out (for example, an `hf-xet` uninstall step, if still listed). These known-issue steps are *volatile* — read them from the live README each time, never from memory or this guide.
+7. **Choose the init variant based on workflow.** This is the most-missed step. The two `rapidfireai init` variants install **different dependency sets** that are not interchangeable. The README §Install shows both invocations; §2 of this guide tells you which one to pick. If the user has already run the wrong variant, they may need to recreate the venv before re-initing.
+8. **Run `rapidfireai doctor`** and confirm no critical failures (Python, GPU/CUDA where applicable, ports, packages). Do not proceed past failures without diagnosing the root cause.
+9. **Start the dashboard stack** with `rapidfireai start` (frontend, MLflow, dispatcher). For the RAG/evals workflow, also start a Jupyter listener as documented in the README — the evals tutorials run inside Jupyter rather than an arbitrary IDE notebook.
+10. **(Remote/cloud machines only) Port-forward** the workflow-appropriate set with `ssh` *before* clicking the dashboard URL. The current set and SSH syntax are in README §Install. VS Code typically auto-forwards the dashboard port; other clients require the explicit `ssh -L` invocation. Skip this step on a local machine.
+11. **Open the tutorial notebook** under `./tutorial_notebooks/` (see §6 for the filename matching the workflow). Two non-obvious requirements:
+    - Notebooks **cannot** run via `python notebook.ipynb` — there is a multiprocessing restriction. Open the notebook in an IDE that supports Jupyter (VS Code, Cursor, JetBrains), or use `rapidfireai jupyter` (mandatory for the RAG/evals tutorials).
+    - The notebook's kernel **must** be set to the `.venv` you created in step 2, not the system Python; otherwise `import rapidfireai` fails. In VS Code / Cursor, click the kernel selector in the upper-right of the notebook and pick the venv interpreter.
+    - The dashboard URL printed by `rapidfireai start` (or by `rapidfireai jupyter` for evals) shows live run progress as cells execute.
+12. **Stop the stack** with `rapidfireai stop` when the user is done.
+
+**Hard rule**: if any specific command above is missing here and present in the README, **use the README's version**. This guide is intentionally silent on volatile commands so it cannot drift from the README.
+
+---
+
+## 4. Agent safety rules
+
+- **Do not** paste, invent, or guess API keys, Hugging Face tokens, or any other secrets. Always ask the user; if they decline, stop.
+- **Do not** assume the user has a GPU. Verify with `nvidia-smi` or `rapidfireai doctor` before suggesting GPU-only workflows.
+- **Do not** assume gated model access. Llama, Gemma, and several Mistral variants require explicit HF approval. Ask before substituting; never download as a different account.
+- **Do not** bypass a failed `init` or `start`. Diagnose the root cause (missing CUDA, wrong Python, port conflict, dependency mismatch). Suppressing errors leads to silent breakage downstream.
+- **Make minimal, explainable edits to user code.** If a change is non-obvious, explain why. Do not refactor surrounding code for style.
+- **Prefer lite tutorial configs** when testing on limited hardware. The full variants assume substantial VRAM.
+
+---
+
+## 5. Troubleshooting
+
+Match the symptom to the diagnostic direction. Specific commands (kill-by-port, SSH-forward, hf-xet uninstall, etc.) are in README §Troubleshooting and §Install — do not paste them from memory.
+
+| Symptom | Likely cause | Diagnostic direction |
+|---|---|---|
+| `ImportError` on `vllm`, `langchain`, or other RAG/eval-only packages | Wrong `init` variant — fit deps installed when evals deps were needed (or vice versa) | Re-run `rapidfireai init` with the variant that matches the workflow; may require recreating the venv |
+| Hugging Face download hangs, or `xet` errors in the traceback | Known `hf-xet` issue (if still listed in the README) | Apply the README's current `hf-xet` workaround |
+| 403 on model download | Gated model + missing/wrong HF auth | Have the user run the README's HF auth step; confirm the user has access granted on the model's HF page |
+| `Address already in use` on a service port | Stale RapidFire services | Run `rapidfireai stop` first; if it persists, see README §Troubleshooting for the kill-by-port command |
+| Frontend not loading from a remote machine | Missing SSH port forward | Forward the workflow-appropriate port set (see README §Install) |
+| `CUDA out of memory` during fit | Model too large for available VRAM | Switch to a `*-lite` tutorial; reduce per-device batch size; consider gradient accumulation |
+| `nvidia-smi` not found, or no GPU detected | CUDA toolkit absent or no GPU on host | Run `rapidfireai doctor`; on CPU-only hosts, only the API-based RAG/evals workflow is viable |
+| `rapidfireai start` exits silently or fails | A service port already bound, or a service init failure | Read the printed log; check service log files reported by `rapidfireai doctor` |
+| Notebook crashes immediately on `Experiment(...)` | Often a multiprocessing restriction (CLI-launched Jupyter cannot spawn child processes) | Run the notebook through an IDE (VS Code / Cursor) or `rapidfireai jupyter`, not raw `python notebook.py` |
+| `ImportError: No module named 'rapidfireai'` *inside the notebook* (but `rapidfireai --version` works in the shell) | Notebook kernel is the system Python, not the project `.venv` | In the IDE's notebook UI, change the kernel/interpreter to the `.venv` you created; restart the kernel and re-run cells |
+
+---
+
+## 6. Tutorials
+
+After `rapidfireai init`, tutorial notebooks are copied to `./tutorial_notebooks/`. Always prefer the on-disk copy — it matches the installed version.
+
+| Workflow | Lite (small VRAM) | Full |
+|---|---|---|
+| SFT | `fine-tuning/rf-tutorial-sft-chatqa-lite.ipynb` | `fine-tuning/rf-tutorial-sft-chatqa.ipynb` |
+| DPO | `post-training/rf-tutorial-dpo-alignment-lite.ipynb` | `post-training/rf-tutorial-dpo-alignment.ipynb` |
+| GRPO | `post-training/rf-tutorial-grpo-mathreasoning-lite.ipynb` | `post-training/rf-tutorial-grpo-mathreasoning.ipynb` |
+| RAG, self-hosted (HF) | `rag-contexteng/rf-tutorial-rag-fiqa.ipynb` | `rag-contexteng/rf-tutorial-rag-fiqa-pgvector.ipynb`, `…-pinecone.ipynb` |
+| RAG, OpenAI / API | `rag-contexteng/rf-tutorial-scifact-generators.ipynb` | `rag-contexteng/rf-tutorial-scifact-full-evaluation.ipynb` |
+| Few-shot eval (no retrieval) | `rag-contexteng/rf-tutorial-gsm8k-fewshot.ipynb` | — |
+
+Online directory: <https://github.com/RapidFireAI/rapidfireai/tree/main/tutorial_notebooks>. Filenames may shift across versions — list `./tutorial_notebooks/` to confirm the current set.
+
+---
+
+## 7. Validation checklist (run before reporting "done")
+
+Before telling the user setup is complete, confirm each:
+
+1. `rapidfireai --version` returns a version string.
+2. `rapidfireai doctor` reports no critical failures.
+3. The right `init` variant ran for the user's workflow (fit *or* evals — not both, not the wrong one).
+4. Hugging Face auth is configured iff the workflow needs it.
+5. `rapidfireai start` brought up the stack without errors. The user can reach the dashboard URL printed by `start`.
+6. (Remote/cloud) The `ssh -L` forward is active in a separate terminal.
+7. (Tutorial path) The notebook's kernel is the project `.venv`, not the system Python. The first import cell (`from rapidfireai import Experiment`) runs without `ImportError`.
+
+If any check fails, stop and diagnose — do not paper over with retries.
+
+---
+
+## 8. References
+
+- **Canonical install instructions and troubleshooting**: <https://github.com/RapidFireAI/rapidfireai/blob/main/README.md>
+- **Full documentation**: <https://oss-docs.rapidfire.ai>
+- **Repository**: <https://github.com/RapidFireAI/rapidfireai>
+- **PyPI**: <https://pypi.org/project/rapidfireai/>
+- **Discord**: <https://discord.gg/6vSTtncKNN>
+- **This guide describes the 0.15+ API surface.** Confirm `rapidfireai --version` against the canonical docs when behavior differs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -260,6 +260,7 @@ local_fit = [
 Homepage = "https://rapidfire.ai"
 Documentation = "https://oss-docs.rapidfire.ai"
 Repository = "https://github.com/RapidFireAI/rapidfireai"
+AI-Agent-Guide = "https://github.com/RapidFireAI/rapidfireai/blob/main/docs/AGENTS.md"
 
 
 [project.scripts]


### PR DESCRIPTION
Add `docs/AGENTS.md` — an operational guide for **AI coding agents** that help an end user **install, configure, and run** `rapidfireai` — and add the hooks that make agents actually **discover** it (a README notice + a PyPI link).

## Two `AGENTS.md` files, opposite audiences — and why this one lives in `docs/`

After #280 the repo has a **root** `AGENTS.md`; this PR adds a **second** one under `docs/`. They are for **different readers**, which is the whole reason for the separate location:

| File | Who it's for | How an agent finds it |
|---|---|---|
| **root `AGENTS.md`** (#280) | **Contributors** — agents/humans working *on* rapidfireai (architecture, build, repo conventions) | **Auto-loaded as project rules** by every agent that follows the `AGENTS.md` convention (Claude Code via the root `CLAUDE.md` pointer, plus Cursor, Codex, Copilot, …) whenever they work in the repo |
| **`docs/AGENTS.md`** (this PR) | **End users' agents** — an AI agent helping someone *install & use* rapidfireai in their **own** project | Read **only when pointed to it**: the README notice and the PyPI `AI-Agent-Guide` URL — both added in this PR |

**Why not put it at the repo root?** Agents that follow the convention auto-load the **root** `AGENTS.md` as the project's standing rules, and there is only one root slot — it belongs to the maintainer guide (#280). If this **end-user install** guide sat at the root, every agent working *on* rapidfireai would load "how to install rapidfireai for a user" as its contributor instructions — wrong audience, wrong rules. Keeping it under `docs/` puts it **outside the auto-load path**, so it's read only by the agents that should read it. (Each file carries a short "you're in the wrong place → go to the other one" scope guard so a misrouted agent self-corrects.)

## What the guide covers

Self-contained for the install/setup journey:

- Audience & source-of-truth rule (README wins on volatile commands)
- Workflow decision tree (RAG vs fine-tuning vs post-training; OpenAI vs self-hosted; lite vs full)
- Setup order, agent safety rules, troubleshooting, tutorials
- A pre-flight validation checklist

It deliberately defers all volatile install content (Python version, `pip install` line, ports, SSH syntax, HF auth) to `README.md` so it cannot drift.

## Discoverability — so agents actually find the guide

The README is the first page an AI coding agent reads when a user asks it to install `rapidfireai` (the canonical entry point on GitHub and PyPI). A guide nothing points to never gets read, so this PR also ships the two discovery hooks:

- a small **collapsible notice at the top of `README.md`** that routes any AI agent to `docs/AGENTS.md` before it starts — the GitHub-side hook;
- an **`AI-Agent-Guide` URL in `pyproject.toml`** that surfaces the guide on the PyPI sidebar and in the installed package metadata — the PyPI-side hook.

(The README notice previously lived in a separate PR; it's consolidated here so the guide and the hooks that surface it land together — no dangling link, and a reviewer sees the notice and the guide it points to in one diff.)

## Files (3)

- `docs/AGENTS.md` (new) — the agent install & setup guide
- `README.md` — collapsible AI-agent notice above `## Overview`
- `pyproject.toml` — `AI-Agent-Guide` project URL

## Dependencies

Independent of #280 at the file level — mergeable in any order. One ordering note: the README notice links the root `AGENTS.md` (added by #280), so that link resolves only once #280 merges — prefer landing **#280 first** (or accept one transient 404 on that single link). The optional integration guide (#283, `docs/agent-integration-guide`) is **stacked on this branch** and extends `docs/AGENTS.md` additively; this PR stands alone as a complete install/setup guide if #283 is never merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and package metadata only; no application or runtime behavior changes.
> 
> **Overview**
> Adds **`docs/AGENTS.md`**, an operational guide for AI coding agents that help end users install and run `rapidfireai`. It routes volatile commands (pip, ports, HF auth) to **README.md**, and adds workflow branching (RAG/evals vs fit; API vs self-hosted; SFT/DPO/GRPO), ordered setup steps, safety rules, a troubleshooting table, tutorial paths, and a pre-flight checklist.
> 
> Registers an **`AI-Agent-Guide`** URL under `[project.urls]` in **`pyproject.toml`** so the guide appears on the PyPI project sidebar.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db16af12751c8805683876407130e44a42c694f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


