### PR TITLE
Make the AI-agent setup guide discoverable from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,17 @@ Rapid experimentation for easier, faster, and more impactful AI customization.
 Built for agentic RAG, context engineering, fine-tuning, and post-training of LLMs and other DL models. 
 Delivers 16-24x higher throughput without extra resources.
 
+<details>
+<summary><strong>🤖 AI coding agent helping a user install or set up rapidfireai? Read first</strong></summary>
+
+If you are an AI coding agent (Claude Code, Cursor, Codex, GitHub Copilot, Windsurf, Aider, Junie, ...) helping a user install or set up `rapidfireai`, read **[`docs/AGENTS.md`](https://github.com/RapidFireAI/rapidfireai/blob/main/docs/AGENTS.md)** ([raw](https://raw.githubusercontent.com/RapidFireAI/rapidfireai/main/docs/AGENTS.md)) first. It is the operational install/setup/troubleshooting guide with a workflow decision tree and safety rules.
+
+Quick decision: **RAG / context engineering** → `rapidfireai init` + `Experiment(..., mode="evals")`. **Fine-tuning / post-training (SFT/DPO/GRPO)** → `rapidfireai init --train` + `Experiment(..., mode="fit")`.
+
+> **Note for agents working *on* rapidfireai itself (contributors)**: this disclosure is for *end-user* assistance. For repo-internal architecture, build, and contributor flow, see root [`AGENTS.md`](https://github.com/RapidFireAI/rapidfireai/blob/main/AGENTS.md) (canonical for all AI coding agents) and [`CONTRIBUTING.md`](https://github.com/RapidFireAI/rapidfireai/blob/main/CONTRIBUTING.md).
+
+</details>
+
 ## Overview
 
 RapidFire AI is a new experiment execution framework that transforms your AI customization experimentation from slow, sequential processes into rapid, intelligent workflows with hyperparallelized execution, dynamic real-time experiment control, and automatic system optimization.


### PR DESCRIPTION
## Why

When a user asks an AI coding agent (Claude Code, Cursor, Codex, GitHub Copilot, Windsurf, Aider, Junie, …) to install or set up `rapidfireai`, the agent's first stop is the **README** — it's the canonical entry point on GitHub and PyPI. We now ship an operational, agent-oriented setup guide at **`docs/AGENTS.md`** (#281), but **nothing in the README points to it**. So an agent has no way to *discover* the guide and will improvise the install (wrong `init` variant, missing port-forward, skipped HF auth, …) instead of following it.

This PR adds the missing **discovery hook**: a short notice near the top of the README that routes any AI coding agent to `docs/AGENTS.md` before it starts. Without it, the guide exists but effectively never gets read. (The PyPI `AI-Agent-Guide` URL added in #281 covers discovery from PyPI; this covers the GitHub README.)

## What

A collapsible `<details>` block placed just above `## Overview` — high enough that an agent sees it early. It:

- points agents to the operational setup guide (`docs/AGENTS.md`) with blob + raw links,
- gives a one-line RAG-vs-fine-tuning decision so the agent picks the right path immediately,
- redirects *contributors* to the root `AGENTS.md` / `CONTRIBUTING.md` instead.

Collapsed by default, so it adds near-zero noise for human readers while staying machine-discoverable.

## Files (1)

- `README.md`

## Dependencies

Independent of the other PRs at the file level. The block links to `docs/AGENTS.md` and root `AGENTS.md` via absolute `blob/main/...` URLs, which resolve once #280 and #281 are merged. To avoid a transient 404 window on `main`, prefer to **merge this last** (after #280 and #281).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README change with no runtime, security, or application code impact; linked paths may 404 on `main` until related docs PRs merge.
> 
> **Overview**
> Adds a collapsible **AI coding agent** section to `README.md` immediately above **Overview**, so agents helping users install or set up `rapidfireai` are directed to **`docs/AGENTS.md`** first (with blob/raw GitHub links).
> 
> The block includes a one-line **RAG vs fine-tuning** path (`rapidfireai init` + `mode="evals"` vs `init --train` + `mode="fit"`) and clarifies that contributors working on the repo should use root **`AGENTS.md`** and **`CONTRIBUTING.md`** instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3e9fcc8b05070c34558cc9fbb90efed7a48c075. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

