### PR TITLE
Pin flashinfer packages to 0.6.13 for consistency

### DIFF
--- a/rapidfireai/cli.py
+++ b/rapidfireai/cli.py
@@ -456,10 +456,10 @@ def install_packages(
         packages.append({"package": f"torchaudio=={torchaudio_version}", "extra_args": ["--upgrade", "--index-url", f"https://download.pytorch.org/whl/{torch_cuda}"]})
         if evals:
             packages.append({"package": f"vllm=={vllm_version}", "extra_args": ["--upgrade"]})
-            packages.append({"package": "flashinfer-python==0.16.3", "extra_args": ["--upgrade"]})
-            packages.append({"package": "flashinfer-cubin==0.16.3", "extra_args": ["--upgrade"]})
+            packages.append({"package": "flashinfer-python==0.6.13", "extra_args": ["--upgrade"]})
+            packages.append({"package": "flashinfer-cubin==0.6.13", "extra_args": ["--upgrade"]})
             if cuda_major + (cuda_minor / 10.0) >= 12.8:
-                packages.append({"package": "flashinfer-jit-cache==0.16.3", "extra_args": ["--upgrade","--index-url", f"https://flashinfer.ai/whl/{flash_cuda}"]})
+                packages.append({"package": "flashinfer-jit-cache==0.6.13", "extra_args": ["--upgrade","--index-url", f"https://flashinfer.ai/whl/{flash_cuda}"]})
             # Re-install torch, torchvision, and torchaudio to ensure compatibility as many packages try and upgrade it
             packages.append({"package": "transformers>=4.56.1,<5.0.0", "extra_args": ["--upgrade"]})           
             packages.append({"package": f"torch=={torch_version}", "extra_args": ["--upgrade", "--index-url", f"https://download.pytorch.org/whl/{torch_cuda}"]})

--- a/rapidfireai/cli.py
+++ b/rapidfireai/cli.py
@@ -456,10 +456,10 @@ def install_packages(
         packages.append({"package": f"torchaudio=={torchaudio_version}", "extra_args": ["--upgrade", "--index-url", f"https://download.pytorch.org/whl/{torch_cuda}"]})
         if evals:
             packages.append({"package": f"vllm=={vllm_version}", "extra_args": ["--upgrade"]})
-            packages.append({"package": "flashinfer-python", "extra_args": ["--upgrade"]})
-            packages.append({"package": "flashinfer-cubin", "extra_args": ["--upgrade"]})
+            packages.append({"package": "flashinfer-python==0.16.3", "extra_args": ["--upgrade"]})
+            packages.append({"package": "flashinfer-cubin==0.16.3", "extra_args": ["--upgrade"]})
             if cuda_major + (cuda_minor / 10.0) >= 12.8:
-                packages.append({"package": "flashinfer-jit-cache", "extra_args": ["--upgrade","--index-url", f"https://flashinfer.ai/whl/{flash_cuda}"]})
+                packages.append({"package": "flashinfer-jit-cache==0.16.3", "extra_args": ["--upgrade","--index-url", f"https://flashinfer.ai/whl/{flash_cuda}"]})
             # Re-install torch, torchvision, and torchaudio to ensure compatibility as many packages try and upgrade it
             packages.append({"package": "transformers>=4.56.1,<5.0.0", "extra_args": ["--upgrade"]})           
             packages.append({"package": f"torch=={torch_version}", "extra_args": ["--upgrade", "--index-url", f"https://download.pytorch.org/whl/{torch_cuda}"]})


### PR DESCRIPTION
## Changes
- Pinned flashinfer packages to 0.6.13 as currently available versions are not in sync

## Changelog Content
### Fixes
- Pinned flashinfer packages to 0.6.13 as currently available versions are not in sync

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes optional eval dependency versions in the CLI installer; no runtime logic or security-sensitive paths.
> 
> **Overview**
> **Pins FlashInfer wheels to a single version** during non-Colab `rapidfireai init` when evaluation/CUDA dependencies are installed.
> 
> `install_packages` now installs `flashinfer-python`, `flashinfer-cubin`, and (for CUDA ≥ 12.8) `flashinfer-jit-cache` as **`==0.6.13`** instead of unpinned names with `--upgrade`. That keeps the three related packages on the same release when upstream versions drift out of sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05b1988817a939acf02efbbde7c29824d3fb5de0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->