### PR TITLE
added a guard for num_gpus > 1 without fsdp_config per issue #291

### DIFF
--- a/rapidfireai/fit/backend/controller.py
+++ b/rapidfireai/fit/backend/controller.py
@@ -234,6 +234,16 @@ class Controller:
                 else:
                     required_workers = self.default_req_workers
 
+            is_fsdp = "fsdp_config" in config_leaf.get("training_args", {})
+            if required_workers > 1 and not is_fsdp:
+                raise ControllerException(
+                    f"num_gpus={required_workers} requires an 'fsdp_config' in "
+                    "training_args. Please add an fsdp_config to enable "
+                    "distributed training, or set num_gpus=1. Without an "
+                    "fsdp_config the reserved workers duplicate compute and "
+                    "write to the same output paths."
+                )
+
             total_steps = self._get_total_step(
                 config_leaf, len_train_dataset, num_chunks, required_workers
             )

--- a/tests/notebooks/repro-issue-291-num-gpus-fsdp.ipynb
+++ b/tests/notebooks/repro-issue-291-num-gpus-fsdp.ipynb
@@ -2,27 +2,10 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
+   "id": "237143e5",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/induranasingh/anaconda3/lib/python3.11/site-packages/pandas/core/arrays/masked.py:61: UserWarning: Pandas requires version '1.3.6' or newer of 'bottleneck' (version '1.3.5' currently installed).\n",
-      "  from pandas.core import (\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INFO 07-15 18:20:52 [importing.py:68] Triton not installed or not compatible; certain GPU-related functions will not be available.\n",
-      "2\n",
-      "False\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from rapidfireai.automl import RFGridSearch, RFModelConfig\n",
     "\n",
@@ -36,8 +19,8 @@
     "    and \"fsdp_config\" in config_leaf[\"training_args\"]\n",
     ")\n",
     "\n",
-    "print(required_workers)  # 2\n",
-    "print(use_fsdp)          # False"
+    "print(required_workers)\n",
+    "print(use_fsdp)"
    ]
   }
  ],

--- a/tests/notebooks/repro-issue-291-num-gpus-fsdp.ipynb
+++ b/tests/notebooks/repro-issue-291-num-gpus-fsdp.ipynb
@@ -1,0 +1,65 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/induranasingh/anaconda3/lib/python3.11/site-packages/pandas/core/arrays/masked.py:61: UserWarning: Pandas requires version '1.3.6' or newer of 'bottleneck' (version '1.3.5' currently installed).\n",
+      "  from pandas.core import (\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO 07-15 18:20:52 [importing.py:68] Triton not installed or not compatible; certain GPU-related functions will not be available.\n",
+      "2\n",
+      "False\n"
+     ]
+    }
+   ],
+   "source": [
+    "from rapidfireai.automl import RFGridSearch, RFModelConfig\n",
+    "\n",
+    "cfg = RFModelConfig(model_name=\"Qwen/Qwen2.5-0.5B-Instruct\", num_gpus=2)\n",
+    "config_leaf = RFGridSearch(configs=[cfg], trainer_type=\"SFT\")._get_runs_fit()[0]\n",
+    "\n",
+    "default_req_workers = 1\n",
+    "required_workers = config_leaf.get(\"num_gpus\", default_req_workers)\n",
+    "use_fsdp = (\n",
+    "    \"training_args\" in config_leaf\n",
+    "    and \"fsdp_config\" in config_leaf[\"training_args\"]\n",
+    ")\n",
+    "\n",
+    "print(required_workers)  # 2\n",
+    "print(use_fsdp)          # False"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "cuda-gpt",
+   "language": "python",
+   "name": "cuda"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Changes

- Added a guard in `Controller._create_models` that raises a `ControllerException` at run-creation time when a run reserves more than one worker (`num_gpus > 1`) but its `training_args` has no `fsdp_config`.

- The check runs after both the warm-started and initial branches, so it validates the final `required_workers` against the final `config_leaf` and also covers warm clones.

- No breaking changes to valid configurations: runs with `num_gpus=1` (the default) or with a proper `fsdp_config` are unaffected.

## Changelog Content
### Additions
- N/A
### Changes
- N/A
### Fixes
- Fixed silent duplicate/racy training when `num_gpus > 1` is set without an `fsdp_config`; run creation now raises a clear error instructing the user to add an `fsdp_config` or set `num_gpus=1` (#291).

## Testing
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change manually
- [x] I have tested this change in the following environments:
  - [x] Local development
  - [ ] Docker environment
  - [ ] Other: _______________

## Screenshots (if applicable)
N/A — this change surfaces a backend `ControllerException` at run-creation time; there is no UI component to capture.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Performance Impact
This PR does not degrade performance. It prevents the case where `num_gpus > 1` without `fsdp_config` causes N workers to run the same training redundantly, wasting compute and dividing throughput by N. By failing fast at run-creation time, it steers users toward either correct FSDP usage or `num_gpus=1`, thus restoring the true functionality of the sweep mechanism without reducing throughput by multiples.

## Related Issues
Fixes #291

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow validation at run creation; only rejects misconfigured multi-GPU runs that were already unsafe, with no change to valid FSDP or single-GPU configs.
> 
> **Overview**
> **Fails fast** when a fit run would reserve more than one worker (`num_gpus > 1`) but `training_args` has no `fsdp_config`, instead of starting redundant multi-worker jobs that duplicate work and clash on output paths.
> 
> In `Controller._create_models`, after `required_workers` is resolved (including warm-started clones that inherit the parent’s worker count), the controller raises `ControllerException` with guidance to add `fsdp_config` or set `num_gpus=1`. Valid setups (`num_gpus=1` or FSDP present) are unchanged.
> 
> A small repro notebook under `tests/notebooks/` documents the `num_gpus=2` without FSDP scenario for issue #291.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 854577caad3b41056183590bfcac437a2bb30539. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->