### PR TITLE
fixed issue #290 (indentation and reference issues)

### DIFF
--- a/rapidfireai/automl/grid_search.py
+++ b/rapidfireai/automl/grid_search.py
@@ -149,22 +149,25 @@ class RFGridSearch(AutoMLAlgorithm):
                                 if num_gpus is not None:
                                     leaf["num_gpus"] = num_gpus
 
-                            if self.trainer_type == "DPO":
-                                leaf["ref_model_config"] = {
-                                    "model_name": config.ref_model_name,
-                                    "model_type": config.ref_model_type,
-                                }
-                                for ref_model_kwargs in ref_model_kwargs_instances:
-                                    leaf["ref_model_config"][
-                                        "model_kwargs"
-                                    ] = ref_model_kwargs
-                                    runs.append(leaf)
-                            elif self.trainer_type == "GRPO":
-                                for reward_func in reward_funcs_instances:
-                                    leaf["reward_funcs"] = reward_func
-                                    runs.append(leaf)
-                            else:
-                                runs.append(leaf)
+                                if self.trainer_type == "DPO":
+                                    leaf["ref_model_config"] = {
+                                        "model_name": config.ref_model_name,
+                                        "model_type": config.ref_model_type,
+                                    }
+                                    for ref_model_kwargs in ref_model_kwargs_instances:
+                                        leaf_copy = copy.deepcopy(leaf)
+                                        leaf_copy["ref_model_config"][
+                                            "model_kwargs"
+                                        ] = ref_model_kwargs
+                                        runs.append(leaf_copy)
+                                elif self.trainer_type == "GRPO":
+                                    for reward_func in reward_funcs_instances:
+                                        leaf_copy = copy.deepcopy(leaf)
+                                        leaf_copy["reward_funcs"] = reward_func
+                                        runs.append(leaf_copy)
+                                else:
+                                    leaf_copy = copy.deepcopy(leaf)
+                                    runs.append(leaf_copy)
 
         return runs
 


### PR DESCRIPTION
## Changes
- **`additional_kwargs` sweeps were being dropped:** the append step sat outside the `additional_kwargs` loop, so only the last value was kept. It's now inside the loop.
- **DPO/GRPO were making duplicate configs:** both reused and mutated the same `leaf` dict, so every run pointed to the same final config. Each run now gets its own `copy.deepcopy(leaf)`, so `reward_funcs` and `ref_model_kwargs` sweeps produce distinct configs.

## Changelog Content
### Additions
- N/A
### Changes
- N/A
### Fixes
- Fixed `additional_kwargs` sweeps (e.g. `formatting_func`, `compute_metrics`, `generation_config`) being dropped, and DPO/GRPO sweeps (`ref_model_kwargs`, `reward_funcs`) creating duplicate configs instead of distinct runs (#290).

## Testing
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change manually
- [ ] I have tested this change in the following environments:
  - [ ] Local development
  - [ ] Docker environment
  - [ ] Other: _______________

## Screenshots (if applicable)
N/A — backend change, no UI. Checked manually: a GRPO `reward_funcs=List([r1, r2])` sweep now returns 2 separate configs (`['r1', 'r2']`) instead of 1.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Performance Impact
No real impact. The extra `copy.deepcopy(leaf)` runs only for DPO/GRPO, once per sweep combination during setup, on small config dicts.

## Related Issues
Fixes #290

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized AutoML config expansion logic with no auth, security, or persistence changes; extra deep copies only at grid-search setup on small dicts.
> 
> **Overview**
> Fixes **fit-mode grid search** in `RFGridSearch._get_runs_fit` so hyperparameter sweeps emit one distinct run per combination instead of collapsing or aliasing configs.
> 
> **`additional_kwargs` sweeps** (e.g. `formatting_func`, `compute_metrics`, `generation_config` via `List(...)`) now append runs inside the `additional_kwargs` loop, so every swept value gets its own run instead of only the last one.
> 
> **DPO, GRPO, and default trainers** no longer reuse and mutate a single `leaf` dict when iterating `ref_model_kwargs` or `reward_funcs`. Each combination is appended as `copy.deepcopy(leaf)` with the right `ref_model_config["model_kwargs"]` or `reward_funcs`, so sweep cardinality matches the Cartesian product of the other dimensions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03954a133260b5dde8493a726e82268176387857. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->